### PR TITLE
bugFix（占い師、シェイプキラー、道連れ表示） 

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -505,6 +505,14 @@ namespace TownOfHost
                 CustomRoles.Egoist or
                 CustomRoles.Jackal;
         }
+        public static bool IsCrewKiller(this PlayerControl player)
+        {
+            return
+                player.GetCustomRole() is
+                CustomRoles.Sheriff or
+                CustomRoles.SillySheriff or
+                CustomRoles.Hunter;
+        }
         public static bool KnowDeathReason(this PlayerControl seer, PlayerControl seen)
         {
             // targetが生きてたらfalse

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -37,9 +37,7 @@ namespace TownOfHost
                 || Mare.KnowTargetRoleColor(target, isMeeting)
                 || (target.Is(CustomRoles.Workaholic) && Workaholic.Seen)
                 || target.Is(CustomRoles.Rainbow)
-                || (FortuneTeller.IsShowTargetRole(seer, target) && isMeeting)
-
-                ;
+                || (seer.Is(CustomRoles.FortuneTeller) && ((FortuneTeller)seer.GetRoleClass()).KnowTargetRoleColor(target) && isMeeting);
         }
         public static bool TryGetData(PlayerControl seer, PlayerControl target, out string colorCode)
         {

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -377,9 +377,6 @@ namespace TownOfHost
                         case CustomRoles.Sympathizer: //共鳴者は2人固定
                             SetupSingleRoleOptions(info.ConfigId, info.Tab, info.RoleName, 2);
                             break;
-                        case CustomRoles.FortuneTeller: //いったん1人固定
-                            SetupSingleRoleOptions(info.ConfigId, info.Tab, info.RoleName, 1);
-                            break;
                         default:
                             SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName);
                             break;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -901,7 +901,7 @@ namespace TownOfHost
                     || ForceLoop
                     || (CustomRoles.Workaholic.IsEnable() && Workaholic.Seen)
                     || CustomRoles.Rainbow.IsEnable()
-                    || seer.Is(CustomRoles.FortuneTeller)
+                    || (seer.Is(CustomRoles.FortuneTeller) && ((FortuneTeller)seer.GetRoleClass()).HasForecastResult())
                     || seer.Is(CustomRoles.Sympathizer)
                     || seer.Is(CustomRoles.AntiComplete)
                     )

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -93,7 +93,7 @@ public static class MeetingHudPatch
             {
                 foreach (var Exiled_Target in RevengeTargetPlayer)
                 {
-                    Utils.SendMessage(string.Format(GetString("RevengeText"), Exiled_Target.Item1.name, Exiled_Target.Item2.name));
+                    Utils.SendMessage(string.Format(GetString("Message.RevengeText"), Exiled_Target.Item1.name, Exiled_Target.Item2.name));
                 }
                 RevengeTargetPlayer.Clear();
             }

--- a/Roles/Impostor/ShapeKiller.cs
+++ b/Roles/Impostor/ShapeKiller.cs
@@ -51,7 +51,9 @@ public sealed class ShapeKiller : RoleBase, IImpostor
     }
     public override bool OnReportDeadBody(PlayerControl reporter, GameData.PlayerInfo target)
     {
-        if (target == null || reporter.PlayerId == target.PlayerId) return true;
+        if (target == null) return true;
+        if (reporter == null || reporter.PlayerId != Player.PlayerId) return true;
+        if (reporter.PlayerId == target.PlayerId) return true;
 
         if (ShapeTarget != null && (CanDeadReport || (!ShapeTarget.Data.IsDead && !ShapeTarget.Data.Disconnected)))
         {


### PR DESCRIPTION
bugFix)道連れの会議表示ができない問題対応
bugFix)占い師の占い結果が全員に見える問題対応
bugFix)占い師の結果が次ゲームに残る問題対応
fix)占い師を２人以上入れられる対応
fix)占い師のキル役職のみ表示でクルーキル陣営を表示する対応
fix)占い師の結果表示の微調整
bugFix)シェイプキラー以外の通報が偽装される問題対応