### PR TITLE
公開ルームの禁止

### DIFF
--- a/Helpers/CustomRolesHelper.cs
+++ b/Helpers/CustomRolesHelper.cs
@@ -54,33 +54,10 @@ namespace TownOfHostY
                 CustomRoles.Impostor or
                 CustomRoles.Shapeshifter;
         }
-        public static bool IsCannotPublicRole(this CustomRoles role)
-        {
-            return
-                role is CustomRoles.Puppeteer
-                    or CustomRoles.BountyHunter
-                    or CustomRoles.Witch
-                    or CustomRoles.SerialKiller
-                    or CustomRoles.Vampire
-                    or CustomRoles.Warlock
-                    or CustomRoles.CursedWolf
-                    or CustomRoles.EvilDiviner
-                    or CustomRoles.MadGuardian
-                    or CustomRoles.MadSheriff
-                    or CustomRoles.SillySheriff
-                    or CustomRoles.Sheriff
-                    or CustomRoles.Medic
-                    or CustomRoles.Arsonist
-                    or CustomRoles.SchrodingerCat
-                    or CustomRoles.PlatonicLover
-                    or CustomRoles.LoveCutter
-                    or CustomRoles.Totocalcio
-                    or CustomRoles.Guarding;
-        }
 
         public static bool IsAddAddOn(this CustomRoles role)
         {
-            return role.IsMadmate() || 
+            return role.IsMadmate() ||
                 role is CustomRoles.Jackal or CustomRoles.JClient;
         }
         public static bool IsAddOn(this CustomRoles role) => role.IsBuffAddOn() || role.IsDebuffAddOn();

--- a/Modules/ClientOptions/ClientOptionItem.cs
+++ b/Modules/ClientOptions/ClientOptionItem.cs
@@ -36,13 +36,6 @@ public sealed class ClientOptionItem : ClientActionItem
         var item = new ClientOptionItem(name, config, optionsMenuBehaviour);
         item.OnClickAction = () =>
         {
-            if(config == Main.CanPublicRoom)
-                if (GameStates.IsLobby)
-                {
-                    ErrorText.Instance.PublicFlag = true;
-                    ErrorText.Instance.AddError(ErrorCode.PublicModeChange);
-                }
-
             config.Value = !config.Value;
             item.UpdateToggle();
             additionalOnClickAction?.Invoke();

--- a/Modules/ErrorText.cs
+++ b/Modules/ErrorText.cs
@@ -58,8 +58,6 @@ namespace TownOfHostY
                 UpdateText();
                 if (HnSFlag)
                     Destroy(this.gameObject);
-                if (PublicFlag)
-                    Destroy(this.gameObject);
             }
         }
         public void LateUpdate()
@@ -102,7 +100,7 @@ namespace TownOfHostY
             }
             else
             {
-                if (!HnSFlag && !PublicFlag)
+                if (!HnSFlag)
                     text += $"{GetString($"ErrorLevel{maxLevel}")}";
                 Text.enabled = true;
             }
@@ -141,7 +139,6 @@ namespace TownOfHostY
         }
 
         public bool HnSFlag;
-        public bool PublicFlag;
     }
     public enum ErrorCode
     {
@@ -166,6 +163,5 @@ namespace TownOfHostY
         TestError2 = 0009202, // 000-920-2 Test Error 2
         TestError3 = 0009303, // 000-930-3 Test Error 3
         HnsUnload = 000_804_1, // 000-804-1 Unloaded By HnS
-        PublicModeChange = 000_503_1, // 000_503_1 PublicModeChange
     }
 }

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -324,12 +324,6 @@ namespace TownOfHostY
             sortedRoleInfo.Where(role => role.CustomRoleType == CustomRoleTypes.Impostor).Do(info =>
             {
                 if (info.RoleName != CustomRoles.StrayWolf)
-                {
-                    if (info.RoleName.IsCannotPublicRole())
-                    {
-                        SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName, isPublic : true);
-                    }
-                    else
                     {
                         switch (info.RoleName)
                         {
@@ -340,7 +334,6 @@ namespace TownOfHostY
                                 SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName);
                                 break;
                         }
-                    }
                     info.OptionCreator?.Invoke();
                 }
             });
@@ -357,15 +350,8 @@ namespace TownOfHostY
                 .SetHeader(true);
 
             sortedRoleInfo.Where(role => role.CustomRoleType == CustomRoleTypes.Madmate).Do(info =>
-            {
-                if (info.RoleName.IsCannotPublicRole())
-                {
-                    SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName, isPublic : true);
-                }
-                else
                 {
                     SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName);
-                }
                 info.OptionCreator?.Invoke();
             });
 
@@ -390,12 +376,6 @@ namespace TownOfHostY
 
             // Crewmate
             sortedRoleInfo.Where(role => role.CustomRoleType == CustomRoleTypes.Crewmate).Do(info =>
-            {
-                if (info.RoleName.IsCannotPublicRole())
-                {
-                    SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName, isPublic : true);
-                }
-                else
                 {
                     switch (info.RoleName)
                     {
@@ -406,7 +386,6 @@ namespace TownOfHostY
                             SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName);
                             break;
                     }
-                }
                 info.OptionCreator?.Invoke();
             });
 
@@ -417,13 +396,6 @@ namespace TownOfHostY
 
             sortedRoleInfo.Where(role => role.CustomRoleType == CustomRoleTypes.Neutral).Do(info =>
             {
-                if (info.RoleName.IsCannotPublicRole())
-                {
-                    SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName, isPublic : true);
-                }
-                else
-                {
-
                     switch (info.RoleName)
                     {
                         case CustomRoles.Jackal: //ジャッカルは1人固定
@@ -436,7 +408,6 @@ namespace TownOfHostY
                             SetupRoleOptions(info.ConfigId, info.Tab, info.RoleName);
                             break;
                     }
-                }
                 info.OptionCreator?.Invoke();
             });
 
@@ -732,7 +703,7 @@ namespace TownOfHostY
                             or "ApplyBanList"
                             or "ChangeIntro";
         }
-        public static void SetupRoleOptions(int id, TabGroup tab, CustomRoles role, CustomGameMode customGameMode = CustomGameMode.Standard, bool isPublic = false)
+        public static void SetupRoleOptions(int id, TabGroup tab, CustomRoles role, CustomGameMode customGameMode = CustomGameMode.Standard)
         {
             if (role.IsVanilla()) return;
             int MaxCount = 15;
@@ -741,7 +712,6 @@ namespace TownOfHostY
             var spawnOption = IntegerOptionItem.Create(id, role.ToString(), new(0, 100, 10), 0, tab, false).SetColor(Utils.GetRoleColor(role))
                 .SetValueFormat(OptionFormat.Percent)
                 .SetHeader(true)
-                .SetIsPublicDontUse(isPublic)
                 .SetGameMode(customGameMode) as IntegerOptionItem;
             var countOption = IntegerOptionItem.Create(id + 1, "Maximum", new(1, MaxCount, 1), 1, tab, false).SetParent(spawnOption)
                 .SetValueFormat(OptionFormat.Players)
@@ -805,7 +775,7 @@ namespace TownOfHostY
             if (parent == null) parent = CustomRoleSpawnChances[PlayerRole];
             var roleName = Utils.GetRoleName(role) + Utils.GetAddonAbilityInfo(role);
             Dictionary<string, string> replacementDic = new() { { "%role%", Utils.ColorString(Utils.GetRoleColor(role), roleName) } };
-            AddOnRoleOptions[(PlayerRole, role)] = BooleanOptionItem.Create(Id, "AddOnAssign%role%", defaultValue, tab, false).SetParent(parent).SetIsPublicDontUse(role == CustomRoles.Guarding);
+            AddOnRoleOptions[(PlayerRole, role)] = BooleanOptionItem.Create(Id, "AddOnAssign%role%", defaultValue, tab, false).SetParent(parent);
             AddOnRoleOptions[(PlayerRole, role)].ReplacementDictionary = replacementDic;
         }
 

--- a/Modules/OptionItem/OptionItem.cs
+++ b/Modules/OptionItem/OptionItem.cs
@@ -163,7 +163,7 @@ namespace TownOfHostY
         // 旧IsHidden関数
         public virtual bool IsHiddenOn(CustomGameMode mode)
         {
-            return IsHidden || (GameMode != CustomGameMode.All && GameMode != mode) || (IsPublicDontUse && IsPublicDontUse == Main.CanPublicRoom.Value);
+            return IsHidden || (GameMode != CustomGameMode.All && GameMode != mode);
         }
 
         public string ApplyFormat(string value)

--- a/Modules/OptionItem/OptionItem.cs
+++ b/Modules/OptionItem/OptionItem.cs
@@ -25,7 +25,6 @@ namespace TownOfHostY
         public Color NameColor { get; protected set; }
         public OptionFormat ValueFormat { get; protected set; }
         public CustomGameMode GameMode { get; protected set; }
-        public bool IsPublicDontUse { get; protected set; }
         public bool IsHeader { get; protected set; }
         public bool IsHidden { get; protected set; }
         public Dictionary<string, string> ReplacementDictionary
@@ -78,7 +77,6 @@ namespace TownOfHostY
             NameColor = Color.white;
             ValueFormat = OptionFormat.None;
             GameMode = CustomGameMode.All;
-            IsPublicDontUse = false;
             IsHeader = false;
             IsHidden = false;
 
@@ -121,7 +119,6 @@ namespace TownOfHostY
         public OptionItem SetColor(Color value) => Do(i => i.NameColor = value);
         public OptionItem SetValueFormat(OptionFormat value) => Do(i => i.ValueFormat = value);
         public OptionItem SetGameMode(CustomGameMode value) => Do(i => i.GameMode = value);
-        public OptionItem SetIsPublicDontUse(bool value) => Do(i => i.IsPublicDontUse = value);
         public OptionItem SetHeader(bool value) => Do(i => i.IsHeader = value);
         public OptionItem SetHidden(bool value) => Do(i => i.IsHidden = value);
 

--- a/Modules/OptionShower.cs
+++ b/Modules/OptionShower.cs
@@ -40,8 +40,7 @@ namespace TownOfHostY
                     sb.Append($"<color={Utils.GetRoleColorCode(CustomRoles.GM)}>{Utils.GetRoleName(CustomRoles.GM)}:</color> {Options.EnableGM.GetString()}\n\n");
                     sb.Append(GetString("ActiveRolesList")).Append('\n');
                     foreach (var kvp in Options.CustomRoleSpawnChances)
-                        if ((kvp.Value.GameMode is CustomGameMode.Standard or CustomGameMode.All && kvp.Value.GetBool()) //スタンダードか全てのゲームモードで表示する役職
-                            && (!kvp.Value.IsPublicDontUse || kvp.Value.IsPublicDontUse != Main.CanPublicRoom.Value && kvp.Value.GetBool()))
+                        if (kvp.Value.GameMode is CustomGameMode.Standard or CustomGameMode.All && kvp.Value.GetBool()) //スタンダードか全てのゲームモードで表示する役職
                             sb.Append($"{Utils.ColorString(Utils.GetRoleColor(kvp.Key), Utils.GetRoleName(kvp.Key))}: {kvp.Value.GetString()}×{kvp.Key.GetCount()}\n");
                     pages.Add(sb.ToString() + "\n\n");
                     sb.Clear();

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -630,7 +630,6 @@ namespace TownOfHostY
                 foreach (var role in CustomRolesHelper.AllRoles)
                 {
                     if (role is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
-                    if (Main.CanPublicRoom.Value && role.IsCannotPublicRole()) continue;
 
                     if (role.IsEnable() && !role.IsVanilla()) SendMessage(GetRoleName(role) + GetString(Enum.GetName(typeof(CustomRoles), role) + "InfoLong"), PlayerId);
                 }
@@ -661,7 +660,6 @@ namespace TownOfHostY
                 foreach (var role in Options.CustomRoleCounts)
                 {
                     if (!role.Key.IsEnable() || role.Key is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
-                    if (Main.CanPublicRoom.Value && role.Key.IsCannotPublicRole()) continue;
 
                     if (role.Key.IsAddOn() || role.Key is CustomRoles.LastImpostor or CustomRoles.Lovers or CustomRoles.Workhorse or CustomRoles.CompreteCrew)
                         sb.Append($"\n〖{GetRoleName(role.Key)}×{role.Key.GetCount()}〗\n");
@@ -697,7 +695,6 @@ namespace TownOfHostY
             foreach (var role in Options.CustomRoleCounts)
             {
                 if (!role.Key.IsEnable() || role.Key is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
-                if (Main.CanPublicRoom.Value && role.Key.IsCannotPublicRole()) continue;
 
                 if (role.Key.IsAddOn() || role.Key is CustomRoles.LastImpostor or CustomRoles.Lovers or CustomRoles.Workhorse or CustomRoles.CompreteCrew)
                     sb.Append($"\n〖{GetRoleName(role.Key)}×{role.Key.GetCount()}〗\n");
@@ -731,7 +728,6 @@ namespace TownOfHostY
             foreach (CustomRoles role in CustomRolesHelper.AllRoles)
             {
                 if (role is CustomRoles.HASFox or CustomRoles.HASTroll) continue;
-                if (Main.CanPublicRoom.Value && role.IsCannotPublicRole()) continue;
 
                 if (role.IsEnable())
                 {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -310,8 +310,6 @@ namespace TownOfHostY
                             Utils.SendMessage(VoiceReader.GetVoiceIdxMsg(), 0);
                         break;
 
-                        break;
-
                     case "/offhat":
                     case "/offskin":
                     case "/offvisor":

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -515,11 +515,6 @@ namespace TownOfHostY
                         Utils.SendMessage(VoiceReader.GetVoiceIdxMsg(), player.PlayerId);
                     break;
 
-                case "/modok":
-                    Main.ConsentModUse[player.GetClient().Id] = player.name;
-                    Utils.SendMessage(string.Format(GetString("Message.ModCheckAgree"), player.name), player.PlayerId);
-                    break;
-
                 default:
                     break;
             }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -310,37 +310,6 @@ namespace TownOfHostY
                             Utils.SendMessage(VoiceReader.GetVoiceIdxMsg(), 0);
                         break;
 
-                    case "/modcheck":
-                    case "/modmsg":
-                        canceled = true;
-                        if (!Main.CanPublicRoom.Value)
-                        {
-                            Utils.SendMessage(string.Format(GetString("Message.ModCheckCommandInvalid")), 0);
-                            break;
-                        }
-                        var msgSend = args[0]?.ToLower() == "/modmsg";
-                        var allOK = true;
-                        var notOKColor = "";
-                        foreach (var pc in Main.AllPlayerControls.Where(x => x.PlayerId != PlayerControl.LocalPlayer.PlayerId))
-                        {
-                            var cl = pc.GetClient();
-                            if (cl != null　&& !Main.ConsentModUse.ContainsKey(cl.Id))
-                            {
-                                allOK = false;
-                                if (msgSend)
-                                    Utils.SendMessageCustom(string.Format(GetString("Message.AnnounceUsingOpenMOD"), Main.PluginVersion), pc.PlayerId);
-                                notOKColor = (notOKColor == "" ? "" : ",") + Palette.GetColorName(pc.Data.DefaultOutfit.ColorId);
-                            }
-                        }
-                        if (allOK)
-                            Utils.SendMessage(string.Format(GetString("Message.ModCheckAllOK")), 0);
-                        else
-                        {
-                            if (msgSend)
-                                Utils.SendMessage(string.Format(GetString("Message.ModCheckMessageSend")), 0);
-                            Utils.SendMessage(string.Format(GetString("Message.ModCheckNotOKColor"), notOKColor), 0);
-                        }
-
                         break;
 
                     case "/offhat":

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -9,7 +9,6 @@ namespace TownOfHostY
     {
         private static ClientActionItem ForceJapanese;
         private static ClientActionItem JapaneseRoleName;
-        private static ClientActionItem CanPublicRoom;
         private static ClientActionItem UnloadMod;
         private static ClientActionItem DumpLog;
 
@@ -27,10 +26,6 @@ namespace TownOfHostY
             if (JapaneseRoleName == null || JapaneseRoleName.ToggleButton == null)
             {
                 JapaneseRoleName = ClientOptionItem.Create("JapaneseRoleName", Main.JapaneseRoleName, __instance);
-            }
-            if (CanPublicRoom == null || CanPublicRoom.ToggleButton == null)
-            {
-                CanPublicRoom = ClientOptionItem.Create("CanPublicRoom", Main.CanPublicRoom, __instance);
             }
             if (UnloadMod == null || UnloadMod.ToggleButton == null)
             {

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -28,13 +28,6 @@ namespace TownOfHostY
                 Logger.SendInGame(message);
                 return false;
             }
-            if (!Main.CanPublicRoom.Value)
-            {
-                var message = GetString("DisabledBySetting");
-                Logger.Info(message, "MakePublicPatch");
-                Logger.SendInGame(message);
-                return false;
-            }
             return true;
         }
     }
@@ -43,7 +36,7 @@ namespace TownOfHostY
     {
         public static void Postfix(MMOnlineManager __instance)
         {
-            if (VersionChecker.IsSupported && Main.CanPublicRoom.Value && Main.AllowPublicRoom) return;
+            if (VersionChecker.IsSupported && Main.AllowPublicRoom) return;
 
             var obj = GameObject.Find("FindGameButton");
             if (obj)
@@ -62,10 +55,6 @@ namespace TownOfHostY
                 else if (!Main.AllowPublicRoom)
                 {
                     message = GetString("DisabledByProgram");
-                }
-                else if (!Main.CanPublicRoom.Value)
-                {
-                    message = GetString("DisabledBySetting1");
                 }
                 textObj.text = $"<size=2>{Utils.ColorString(Color.red, message)}</size>";
             }

--- a/Patches/ClientPatch.cs
+++ b/Patches/ClientPatch.cs
@@ -43,7 +43,7 @@ namespace TownOfHostY
     {
         public static void Postfix(MMOnlineManager __instance)
         {
-            if (VersionChecker.IsSupported && Main.CanPublicRoom.Value) return;
+            if (VersionChecker.IsSupported && Main.CanPublicRoom.Value && Main.AllowPublicRoom) return;
 
             var obj = GameObject.Find("FindGameButton");
             if (obj)
@@ -58,6 +58,10 @@ namespace TownOfHostY
                 if (!VersionChecker.IsSupported)
                 {
                     message = GetString("UnsupportedVersion");
+                }
+                else if (!Main.AllowPublicRoom)
+                {
+                    message = GetString("DisabledByProgram");
                 }
                 else if (!Main.CanPublicRoom.Value)
                 {

--- a/Patches/CredentialsPatch.cs
+++ b/Patches/CredentialsPatch.cs
@@ -93,21 +93,12 @@ namespace TownOfHostY
                         SpecialEventText.color = col;
                     }
                 }
-                if (!Main.CanPublicRoom.Value && Main.IsOneNightRelease && CultureInfo.CurrentCulture.Name == "ja-JP")
+                if (Main.IsOneNightRelease && CultureInfo.CurrentCulture.Name == "ja-JP")
                 {
                     SpecialEventText.text = "TOH_Yへようこそ！" +
                         "\n<size=55%>遂にシェリフ等役職が完全復活！" +
                         "\n全役職が最新バージョンで遊べるようになりました。(非公開ルームのみ)" +
                         "\n公開ルームで遊びたい場合は設定(歯車)から[公開ルーム可能]をオンにした制限版で。" +
-                        "\nこれからもTOH_Yをよろしくお願いします！\n</size><size=40%>\n次回アップデートはちょっと先になりそう。</size>";
-                    SpecialEventText.color = Color.yellow;
-                }
-                if (Main.CanPublicRoom.Value && Main.IsOneNightRelease && CultureInfo.CurrentCulture.Name == "ja-JP")
-                {
-                    SpecialEventText.text = "TOH_YSへようこそ！" +
-                        "\n<size=55%>制限版では公開ルーム/非公開ルームどちらでも使用できます。" +
-                        "\nただし、一部役職が使用できません。(非表示にしてあります)" +
-                        "\n非公開ルームで遊ぶ場合は設定(歯車)から[公開ルーム可能]をオフにした完全版で。" +
                         "\nこれからもTOH_Yをよろしくお願いします！\n</size><size=40%>\n次回アップデートはちょっと先になりそう。</size>";
                     SpecialEventText.color = Color.yellow;
                 }
@@ -143,10 +134,7 @@ namespace TownOfHostY
                 logoTransform.parent = rightpanel;
                 logoTransform.localPosition = new(0f, 0.18f, 1f);
                 //logoTransform.localScale *= 1f;
-                if(!Main.CanPublicRoom.Value)
-                    TohLogo.sprite = Utils.LoadSprite("TownOfHost_Y.Resources.TownOfHostY-Logo.png", 300f);
-                else
-                    TohLogo.sprite = Utils.LoadSprite("TownOfHost_Y.Resources.TownOfHostYS-Logo.png", 300f);
+                TohLogo.sprite = Utils.LoadSprite("TownOfHost_Y.Resources.TownOfHostY-Logo.png", 300f);
             }
         }
         [HarmonyPatch(typeof(ModManager), nameof(ModManager.LateUpdate))]

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -70,7 +70,7 @@ namespace TownOfHostY
                 if (!AmongUsClient.Instance.AmHost) return;
 
                 // Make Public Button
-                if (!Main.AllowPublicRoom || !Main.CanPublicRoom.Value || !VersionChecker.IsSupported)
+                if (!Main.AllowPublicRoom || !VersionChecker.IsSupported)
                 {
                     __instance.MakePublicButton.color = Palette.DisabledClear;
                     __instance.privatePublicText.color = Palette.DisabledClear;
@@ -253,7 +253,7 @@ namespace TownOfHostY
             }
         }
     }
-    
+
     [HarmonyPatch(typeof(TextBoxTMP), nameof(TextBoxTMP.SetText))]
     public static class HiddenTextPatch
     {

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -22,30 +22,6 @@ namespace TownOfHostY
         private static TextMeshPro timerText;
         private static SpriteRenderer cancelButton;
 
-        [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.ReallyBegin))]
-        public class GameStartManagerReallyBeginPatch
-        {
-            public static void Postfix(GameStartManager __instance, bool neverShow)
-            {
-                if (!Main.CanPublicRoom.Value) return;
-                if (GameStartManager.Instance.startState != GameStartManager.StartingStates.Countdown) return;
-                Logger.Info($"CanPublicRoom: {Main.CanPublicRoom.Value}", "GameStartManagerStart");
-                foreach (var pc in Main.AllPlayerControls.Where(x => x.PlayerId != PlayerControl.LocalPlayer.PlayerId))
-                {
-                    var target = pc.GetClient();
-                    if (target == null) continue;
-                    Logger.Info($"ConsentCheck name: {target.PlayerName}, id; {target.Id}, check: {Main.ConsentModUse.ContainsKey(target.Id)}", "GameStartManagerStart");
-                    if (!Main.ConsentModUse.ContainsKey(target.Id))
-                    {
-                        AmongUsClient.Instance.KickPlayer(target.Id, false);
-                        Utils.SendMessage(string.Format(GetString("Message.ModCheckKick"), target.PlayerName));
-                    }
-
-                }
-                return;
-            }
-        }
-
         [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Start))]
         public class GameStartManagerStartPatch
         {

--- a/Patches/GetBroadcastVersionPatch.cs
+++ b/Patches/GetBroadcastVersionPatch.cs
@@ -7,7 +7,7 @@ public static class GetBroadcastVersionPatch
 {
     public static bool Prefix(ref int __result)
     {
-        if (GameStates.IsLocalGame || Main.CanPublicRoom.Value)
+        if (GameStates.IsLocalGame)
         {
             return true;
         }

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -321,7 +321,7 @@ namespace TownOfHostY
 
             if (AmongUsClient.Instance.AmHost)
             {//実行クライアントがホストの場合のみ実行
-                if (GameStates.IsLobby && (!Main.AllowPublicRoom || !Main.CanPublicRoom.Value || !VersionChecker.IsSupported) && AmongUsClient.Instance.IsGamePublic)
+                if (GameStates.IsLobby && (!Main.AllowPublicRoom || !VersionChecker.IsSupported) && AmongUsClient.Instance.IsGamePublic)
                     AmongUsClient.Instance.ChangeGamePublic(false);
 
                 if (GameStates.IsInTask && ReportDeadBodyPatch.CanReport[__instance.PlayerId] && ReportDeadBodyPatch.WaitReport[__instance.PlayerId].Count > 0)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -378,10 +378,6 @@ namespace TownOfHostY
                         else __instance.cosmetics.nameText.text = $"<color=#ff0000><size=1.2>v{ver.version}</size>\n{__instance?.name}</color>";
                     }
                     else __instance.cosmetics.nameText.text = __instance?.Data?.PlayerName;
-
-                    var client = __instance.GetClient();
-                    var consent = Main.CanPublicRoom.Value && client != null && Main.ConsentModUse.ContainsKey(client.Id) ? "<color=#ff00ff>ModOK</color>" : "";
-                    __instance.cosmetics.nameText.text += consent;
                 }
                 if (GameStates.IsInGame)
                 {

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -120,19 +120,8 @@ namespace TownOfHostY
                 _ = new LateTask(() =>
                 {
                     if (client.Character == null) return;
-                    if (Main.CanPublicRoom.Value)
-                    {
-                        if (client.Character.PlayerId == PlayerControl.LocalPlayer.PlayerId)
-                            Utils.SendMessageCustom(string.Format(GetString("Message.AnnounceUsingOpenMODAttention"), Main.PluginVersion), client.Character.PlayerId);
-                        else
-                            Utils.SendMessageCustom(string.Format(GetString("Message.AnnounceUsingOpenMOD"), Main.PluginVersion), client.Character.PlayerId);
-                    }
-                    else
-                    {
-                        if (client.Character.PlayerId == PlayerControl.LocalPlayer.PlayerId) return;
-                        if (AmongUsClient.Instance.IsGamePublic) Utils.SendMessage(string.Format(GetString("Message.AnnounceUsingTOH"), Main.PluginVersion), client.Character.PlayerId);
-                        TemplateManager.SendTemplate("welcome", client.Character.PlayerId, true);
-                    }
+                    if (AmongUsClient.Instance.IsGamePublic) Utils.SendMessage(string.Format(GetString("Message.AnnounceUsingTOH"), Main.PluginVersion), client.Character.PlayerId);
+                    TemplateManager.SendTemplate("welcome", client.Character.PlayerId, true);
                 }, 3f, "Welcome Message");
                 if (Options.AutoDisplayLastResult.GetBool() && PlayerState.AllPlayerStates.Count != 0 && Main.clientIdList.Contains(client.Id))
                 {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -166,15 +166,12 @@ namespace TownOfHostY
                     PlayerControl.LocalPlayer.Data.IsDead = true;
                 }
                 Dictionary<(byte, byte), RoleTypes> rolesMap = new();
-                if (!Main.CanPublicRoom.Value)
-                {
-                    AssignDesyncRole(CustomRoles.Sheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                    AssignDesyncRole(CustomRoles.SillySheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                    AssignDesyncRole(CustomRoles.Arsonist, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                    AssignDesyncRole(CustomRoles.MadSheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                    AssignDesyncRole(CustomRoles.PlatonicLover, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                    AssignDesyncRole(CustomRoles.Totocalcio, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
-                }
+                AssignDesyncRole(CustomRoles.Sheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
+                AssignDesyncRole(CustomRoles.SillySheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
+                AssignDesyncRole(CustomRoles.Arsonist, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
+                AssignDesyncRole(CustomRoles.MadSheriff, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
+                AssignDesyncRole(CustomRoles.PlatonicLover, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
+                AssignDesyncRole(CustomRoles.Totocalcio, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
                 AssignDesyncRole(CustomRoles.Hunter, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
                 AssignDesyncRole(CustomRoles.Jackal, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
                 AssignDesyncRole(CustomRoles.DarkHide, AllPlayers, senders, rolesMap, BaseRole: RoleTypes.Impostor);
@@ -283,7 +280,6 @@ namespace TownOfHostY
                 {
                     if (role.IsVanilla()) continue;
                     if (role is CustomRoles.HASTroll or CustomRoles.HASFox) continue;
-                    if (Main.CanPublicRoom.Value && role.IsCannotPublicRole()) continue;
 
                     if (role is CustomRoles.Sheriff or CustomRoles.Arsonist
                         or CustomRoles.Hunter or CustomRoles.SillySheriff or CustomRoles.MadSheriff
@@ -319,8 +315,7 @@ namespace TownOfHostY
                 AssignCustomSubRolesFromList(CustomRoles.TieBreaker, allPlayersbySub);
                 AssignCustomSubRolesFromList(CustomRoles.NonReport, allPlayersbySub);
                 AssignCustomSubRolesFromList(CustomRoles.PlusVote, allPlayersbySub);
-                if (!Main.CanPublicRoom.Value)
-                    AssignCustomSubRolesFromList(CustomRoles.Guarding, allPlayersbySub);
+                AssignCustomSubRolesFromList(CustomRoles.Guarding, allPlayersbySub);
                 AssignCustomSubRolesFromList(CustomRoles.AddBait, allPlayersbySub);
                 AssignCustomSubRolesFromList(CustomRoles.Refusing, allPlayersbySub);
 

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -837,10 +837,6 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "Message.VoiceNow","Changed the reading of the {0} to {1}.","{0} の現在の読上げは {1} です",,,,
 "Message.VoiceChange","Changed the reading of the {0} to {1}.","{0} の読上げを {1} に変更しました",,,,
 "Message.VoiceChangeFailed","Failed to change {0} chat reading.","{0} の読上げを変更できませんでした",,,,
-"Message.ModCheckCommandInvalid","Mod check command invalid in current mode.","公開ルーム不可のため/modcheckコマンド無効です",,,,
-"Message.ModCheckAllOK","All players consented to the mod.","全プレイヤーがMod同意しました",,,,
-"Message.ModCheckNotOKColor","Not consented color: {0}","Mod未同意の色: {0}",,,,
-"Message.ModCheckMessageSend","A confirmation message has been sent to players who have not consented to the mod.","Mod未同意のプレイヤーに確認メッセージを送信しました",,,,
 "Message.ModCheckAgree","I agree to use mods. Player: {0}\n\nPlease exit the room to cancel.","MODの使用に合意しました。\n　Player: {0}\n\n※取り消す場合は部屋を抜けてください",,,,
 "Message.ModCheckKick","{0} has been kicked due to lack of agreement to use mods.","{0} はMOD使用の合意がないためキックされました",,,,
 

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -837,7 +837,6 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "Message.VoiceNow","Changed the reading of the {0} to {1}.","{0} の現在の読上げは {1} です",,,,
 "Message.VoiceChange","Changed the reading of the {0} to {1}.","{0} の読上げを {1} に変更しました",,,,
 "Message.VoiceChangeFailed","Failed to change {0} chat reading.","{0} の読上げを変更できませんでした",,,,
-"Message.ModCheckAgree","I agree to use mods. Player: {0}\n\nPlease exit the room to cancel.","MODの使用に合意しました。\n　Player: {0}\n\n※取り消す場合は部屋を抜けてください",,,,
 
 "IsNimrodMeetingTitle","【The Nimrod's choice】","【ニムロッドの処刑選択】"
 "IsNimrodMeetingText","The Nimrod should choose who to execute.\nIt's time for others to wait quietly...","ニムロッドは処刑する人を選択してください。\n他の人は静かに待つ時間...",

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -827,8 +827,6 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "Message.BanedByBanList","{0} has been banned because it has been banned in the past.","{0}は過去にBAN済みのためBANされました。","{0} 已被封禁，因其之前就被封禁过","因為{0}在被記錄在黑名單中，所以禁止了{0}再次進入此房間。","{0} был заблокирован, потому что он был заблокирован в прошлый раз",""
 "Message.KickedByNoFriendCode","{0} was kicked because the friend code does not exist.","{0}はフレンドコードが存在しないためキックされました。","{0}被踢出，因其好友编号无效。","{0}因為沒有好友代碼，所以踢出了他。","{0} был кикнут, так как у него нет кода друга",""
 "Message.AddedPlayerToBanList","Added {0} to the ban list.","{0}をBANリストに追記しました。","{0}已被添加到封禁名单","已將 {0} 加入到黑名單中，此玩家將無法再進入你的房間。(需安裝TOH模組)","{0} был добавлен в список забаненых игроков",""
-"Message.AnnounceUsingOpenMODAttention","This room uses TownOfHost_Y v{0}.\nPlease check GitHub for detailed roles descriptions.","<size=200%><color=#03a0e3>TownOfHost</color><color=yellow> Y</color></size>\n\nこの部屋はMOD TownOfHost_YS v{0}を使用しています\n\n<color=red>【重要】</color>\nMODの使用にあたり、<color=red>全プレイヤーにMOD使用の同意を取る必要があります</color>\n各プレイヤーに /ModOK コマンドを使用してMOD使用の同意を取ってください\n各プレイヤーには同意コマンドを入力するよう案内が表示されます\n\n※コマンド未入力の場合はスタート時にキックされ<color=red>ゲームに参加できません</color>\n※再度同意コマンドの入力を促す場合は /modmsg コマンドを使用してください\n※詳細は TownOfHost_Y のGitHubを参照ください",,,,
-"Message.AnnounceUsingOpenMOD","This room uses TownOfHost_Y v{0}.\nPlease check GitHub for detailed roles descriptions.","<size=200%><color=#03a0e3>TownOfHost</color><color=yellow> Y</color></size>\n\nこの部屋はMOD TownOfHost_YS v{0}を使用しています\n\n<color=red>【重要】</color>\nこの部屋ではMODを使用しています\nMOD使用について同意する場合は下記コマンドを入力してください\n<color=red>　/ModOK</color>\n\n※コマンド未入力の場合はスタート時にキックされ<color=red>ゲームに参加できません</color>\n\nMODの詳細は TownOfHost_Y のGitHubを参照ください\nゲーム中の不具合などはTownOfHost_Yのディスコードへ報告してください\n※この部屋での不具合等について<color=red>AmongUs公式への問合せはしない</color>でください",,,,
 "Message.AnnounceUsingTOH","This room uses TownOfHost_Y v{0}.\n/now can be used to check the current settings.\nPlease check GitHub for detailed roles descriptions.","この部屋はTownOfHost_YS v{0}を使用しています。本家TOH、現行版TOH_Yを含む他MOD導入中の方との共存は出来ません。\n/nで現在の設定、/h nで現在の設定の説明が確認できます。","本房间使用TownOfHost_Y mod v{0}。\n可以使用/now来查询当前设置。\n请前往本mod的Github页面来获取详细的职业信息。","本房間使用TownOfHost_Y v{0}。\n可以使用/n來查詢目前設定。\n若要獲得進一步的職業介紹(並沒有繁體中文翻譯版本)請前往本模組的Github頁面來獲得。","В этой комнате используется TownOfHost_Y v{0}. Используйте  \n/now чтобы увидеть текущие настройки. \nПожалуйста посетите GitHub для получения подробного описания мода и ролей.","Esta sala está usando TownOfHost_Y versão {0} .\nO comando /now pode ser usado para ver as configurações atuais.\nPor favor, verifique o GitHub para descrições detalhadas das classes."
 "Message.isReport","The meeting was started by the discovery of a dead body.\nReported dead body：{0}","死体発見により会議が開かれました。\n通報された死体：{0}","会议以发现一具尸体开始。\n报告的尸体：{0}"
 "Message.isButton","The meeting was started by an emergency button.","緊急ボタンにより会議が開かれました。","会议以使用紧急按钮开始."
@@ -1041,7 +1039,6 @@ PanAlive13,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "nameChangeMode.None","None","なし",
 "nameChangeMode.Crew","Crewmate","クルーメイト","船员","船員","Член Экипажа","Tripulante"
 "nameChangeMode.Color","Color","色名",
-"ExtendedChat","Extended Chat","拡張チャット",,,,
 
 "VoiceReaderMode","VoiceReader Mode","チャットの読上げ",,,,
 "VoiceReaderHost","Host","ホスト",,,,

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -790,7 +790,6 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "TOHOptions","<color=#ffff00>TOH_Y</color> Options","<color=#ffff00>TOH_Y</color>の設定","","","",""
 "ForceJapanese","Force Japanese","日本語に強制","强制使用日语","強制使用日語","Принудительный Японский","Forçar Japonês"
 "JapaneseRoleName","Japanese Role Name","日本語の役職名","用日语显示职业名","","Японские названия ролей",""
-"CanPublicRoom","Can Public Room","公開ルーム可能",
 "UnloadMod","Disable The Mod","Modを無効化","切换为原版","","Отключить мод",""
 "UnloadWarning","<color=#ffff00><size=200%>Warning</size></color>\n\nTo re-enable the mod, you must restart the game. Would you like to continue anyway?","<color=#ffff00><size=200%>警告</size></color>\n\nModを再び有効化するにはゲームの再起動が必要です。本当に無効化しますか？","<color=#ffff00><size=200%>警告：</size></color>\n\n切换后需要重启游戏来恢复模组，确定要切换原版吗？","","<color=#ffff00><size=200%>Внимание!</size></color>\n\nДля повторного включения мода необходимо перезапустить игру. Вы все равно хотите продолжить?",""
 "CannotUnloadDuringGame","The mod cannot be disabled during a game.","試合中はModを無効化できません","游戏中不能切换原版","","Мод нельзя отключить во время игры.",""
@@ -906,7 +905,6 @@ PanAlive13,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "ERR-000-920-2","Test Error Lv.2","テストエラーLv2","测试错误Lv2","測試錯誤Lv2","Ошибка теста - Lv2","Erro de Teste Nvl.2"
 "ERR-000-930-3","Test Error Lv.3","テストエラーLv3","测试错误Lv3","測試錯誤Lv3","Ошибка теста - Lv3","Erro de Teste Nvl.3"
 "ERR-000-804-1","TownOfHost does not support the Vanilla HnS, so unloaded.","現在バニラのHide And Seekはサポートされていません。modを無効化しました。","TOH不支持原版躲猫猫, mod因此失效","Town Of Host模組尚未支援原版的Hide And Seek模式，所以模組將暫時卸載。","Мод не поддерживает обычные Прятки. Мод был отключён",""
-"ERR-000-503-1","Public room settings have been changed. Please create the room again.","公開ルーム設定が変更されました。部屋を立て直してください。"
 "#### 001 Main"
 "ERR-001-000-3","Main dictionary has duplicated keys.","MainのDictonaryでKeyの重複が発生しています。","在主目录出现重复密钥","在主目錄出現重複密鑰","Дублирование ключей происходит в основном словаре.","Dicionário principal tem chaves duplicadas."
 "#### 002 Support"
@@ -940,8 +938,6 @@ PanAlive13,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "ModBrokenMessage","The MOD file is damaged.\nPlease reinstall.","MODを構成するファイルが破損しています。\nもう一度導入しなおしてください。","模组文件损坏。\n请重新安装本模组。","模組檔案損壞\n請重新安裝模組","Мод был поврежден.\nПожалуйста переустановите его снова.","Os arquivos do MOD estão danificados.\nPor favor reinstale."
 "UnsupportedVersion","Unsupported AmongUs version.\nPlease update.","サポートされていないAmongUsバージョンです。\nゲームをアップデートしてください。","","","Неподдерживаемая версия AmongUs.\nПожалуйста, обновите игру",""
 "DisabledByProgram","Public rooms have been disabled by the program","公開ルームはプログラムによって無効化されています","公开房间的操作已被程序禁用","公開房間的操作已經被程式禁用","Создание публичного лобби отключена программой","Salas públicas foram desativadas pelo programa"
-"DisabledBySetting","Public rooms have been disabled by the Setting","公開ルームは設定によって無効化されています。\n歯車から設定して部屋を作りなおしてください。",
-"DisabledBySetting1","Public rooms have been disabled by the Setting","公開ルームは設定によって無効化されています。\n設定から[公開ルーム可能]をオンにしてください。",
 "EnterVentToWin","Enter Vent to Win!!","ベントに入って勝利しろ!!","跳管道来获得胜利！","跳管道來獲得勝利!!","Запрыгните в вентиляцию чтобы победить!!","Entre no Duto Para Ganhar!!!"
 "FireworksPutPhase","{0} Fireworks Left","あと{0}個置け","还要安放{0}枚烟花","還需要安裝{0}枚煙火","Осталось {0} Фейерверков","Restam {0} Fogos de Artifício"
 "FireworksWaitPhase","Wait for it...","時を待て...","耐心等待....","等待時機...","Подожди время...","Espere o momento certo..."

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -841,8 +841,8 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "Message.ModCheckAllOK","All players consented to the mod.","全プレイヤーがMod同意しました",,,,
 "Message.ModCheckNotOKColor","Not consented color: {0}","Mod未同意の色: {0}",,,,
 "Message.ModCheckMessageSend","A confirmation message has been sent to players who have not consented to the mod.","Mod未同意のプレイヤーに確認メッセージを送信しました",,,,
-"Message.ModCheckAgree","I agree to use mods. Player: {0}\n\nPlease exit the room to cancel.","MODの使用に同意しました。\n　Player: {0}\n\n※取り消す場合は部屋を抜けてください",,,,
-"Message.ModCheckKick","{0} has been kicked due to lack of agreement to use mods.","{0} はMOD使用の同意がないためキックされました",,,,
+"Message.ModCheckAgree","I agree to use mods. Player: {0}\n\nPlease exit the room to cancel.","MODの使用に合意しました。\n　Player: {0}\n\n※取り消す場合は部屋を抜けてください",,,,
+"Message.ModCheckKick","{0} has been kicked due to lack of agreement to use mods.","{0} はMOD使用の合意がないためキックされました",,,,
 
 "IsNimrodMeetingTitle","【The Nimrod's choice】","【ニムロッドの処刑選択】"
 "IsNimrodMeetingText","The Nimrod should choose who to execute.\nIt's time for others to wait quietly...","ニムロッドは処刑する人を選択してください。\n他の人は静かに待つ時間...",

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -838,7 +838,6 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "Message.VoiceChange","Changed the reading of the {0} to {1}.","{0} の読上げを {1} に変更しました",,,,
 "Message.VoiceChangeFailed","Failed to change {0} chat reading.","{0} の読上げを変更できませんでした",,,,
 "Message.ModCheckAgree","I agree to use mods. Player: {0}\n\nPlease exit the room to cancel.","MODの使用に合意しました。\n　Player: {0}\n\n※取り消す場合は部屋を抜けてください",,,,
-"Message.ModCheckKick","{0} has been kicked due to lack of agreement to use mods.","{0} はMOD使用の合意がないためキックされました",,,,
 
 "IsNimrodMeetingTitle","【The Nimrod's choice】","【ニムロッドの処刑選択】"
 "IsNimrodMeetingText","The Nimrod should choose who to execute.\nIt's time for others to wait quietly...","ニムロッドは処刑する人を選択してください。\n他の人は静かに待つ時間...",

--- a/Roles/AddOns/Common/Guarding.cs
+++ b/Roles/AddOns/Common/Guarding.cs
@@ -23,7 +23,7 @@ public static class Guarding
 
     public static void SetupCustomOption()
     {
-        SetupRoleOptions(Id, TabGroup.Addons, CustomRoles.Guarding, isPublic : true);
+        SetupRoleOptions(Id, TabGroup.Addons, CustomRoles.Guarding);
     }
     [GameModuleInitializer]
     public static void Init()

--- a/main.cs
+++ b/main.cs
@@ -98,7 +98,6 @@ namespace TownOfHostY
         public static List<PlayerControl> LoversPlayers = new();
         public static bool isLoversDead = true;
         public static Dictionary<byte, float> AllPlayerKillCooldown = new();
-        public static Dictionary<int, string> ConsentModUse = new();
 
         /// <summary>
         /// 基本的に速度の代入は禁止.スピードは増減で対応してください.

--- a/main.cs
+++ b/main.cs
@@ -29,7 +29,7 @@ namespace TownOfHostY
         // modの色 / Mod Color (Default: #00bfff)
         public static readonly string ModColor = "#ffff00";
         // 公開ルームを許可する / Allow Public Room (Default: true)
-        public static readonly bool AllowPublicRoom = true;
+        public static readonly bool AllowPublicRoom = false;
         // フォークID / ForkId (Default: OriginalTOH)
         public static readonly string ForkId = "TOH_Y";
         // Discordボタンを表示するか / Show Discord Button (Default: true)

--- a/main.cs
+++ b/main.cs
@@ -68,7 +68,6 @@ namespace TownOfHostY
         public static ConfigEntry<string> HideColor { get; private set; }
         public static ConfigEntry<bool> ForceJapanese { get; private set; }
         public static ConfigEntry<bool> JapaneseRoleName { get; private set; }
-        public static ConfigEntry<bool> CanPublicRoom { get; private set; }
         public static ConfigEntry<float> MessageWait { get; private set; }
 
         public static Dictionary<byte, PlayerVersion> playerVersion = new();
@@ -135,7 +134,6 @@ namespace TownOfHostY
             HideColor = Config.Bind("Client Options", "Hide Game Code Color", $"{ModColor}");
             ForceJapanese = Config.Bind("Client Options", "Force Japanese", false);
             JapaneseRoleName = Config.Bind("Client Options", "Japanese Role Name", true);
-            CanPublicRoom = Config.Bind("Client Options", "Can Public Room", false);
             DebugKeyInput = Config.Bind("Authentication", "Debug Key", "");
 
             Logger = BepInEx.Logging.Logger.CreateLogSource("TOH_Y");


### PR DESCRIPTION
- プログラム設定により公開ルームを禁止
  - 公開ルーム検索に反映されていなかった問題を修正
- コマンド同意関連をリバート
- `CanPublicRoom`クライアント設定以下公開ルーム関連のものを削除

d303722f8 の差分が大きすぎて影響範囲が正確に予測できず，細部のチェックは行えていないため，もしマージする場合は確認をお願いします
