### PR TITLE
bugFix 暗転、はぐれ狼の問題対応

### DIFF
--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -25,6 +25,7 @@ namespace TownOfHostY
 
             Logger.Info("-----------ゲーム終了-----------", "Phase");
             if (!GameStates.IsModHost) return;
+            if (Main.tempImpostorNum > 0) Main.NormalOptions.NumImpostors = Main.tempImpostorNum;
             SummaryText = new();
             SDSummaryText = new();
             foreach (var id in PlayerState.AllPlayerStates.Keys)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -354,7 +354,7 @@ namespace TownOfHostY
             if (__instance.AmOwner)
             {
                 //キルターゲットの上書き処理
-                if (GameStates.IsInTask && !(__instance.Is(CustomRoleTypes.Impostor) || __instance.Is(CustomRoles.Egoist)) && __instance.CanUseKillButton() && !__instance.Data.IsDead)
+                if (GameStates.IsInTask && !((__instance.Is(CustomRoleTypes.Impostor) && !__instance.Is(CustomRoles.StrayWolf)) || __instance.Is(CustomRoles.Egoist)) && __instance.CanUseKillButton() && !__instance.Data.IsDead)
                 {
                     var players = __instance.GetPlayersInAbilityRangeSorted(false);
                     PlayerControl closest = players.Count <= 0 ? null : players[0];

--- a/Roles/Neutral/Arsonist.cs
+++ b/Roles/Neutral/Arsonist.cs
@@ -21,6 +21,7 @@ public sealed class Arsonist : RoleBase, IKiller
             SetupOptionItem,
             "アーソニスト",
             "#ff6633",
+            true,
             introSound: () => GetIntroSound(RoleTypes.Crewmate)
         );
     public Arsonist(PlayerControl player)

--- a/Roles/Neutral/DarkHide.cs
+++ b/Roles/Neutral/DarkHide.cs
@@ -22,7 +22,8 @@ namespace TownOfHostY.Roles.Neutral
                 SetupOptionItem,
                 "ダークハイド",
                 "#483d8b",
-                countType : CountTypes.Crew
+                true,
+                countType: CountTypes.Crew
             );
         public DarkHide(PlayerControl player)
         : base(

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -18,6 +18,7 @@ namespace TownOfHostY.Roles.Neutral
                 SetupOptionItem,
                 "ジャッカル",
                 "#00b4eb",
+                true,
                 countType: CountTypes.Jackal
             );
         public Jackal(PlayerControl player)

--- a/Roles/Neutral/Opportunist.cs
+++ b/Roles/Neutral/Opportunist.cs
@@ -19,7 +19,8 @@ public sealed class Opportunist : RoleBase, IKiller, IAdditionalWinner
             50100,
             SetupOptionItem,
             "オポチュニスト",
-            "#00ff00"
+            "#00ff00",
+            true
         );
     public Opportunist(PlayerControl player)
     : base(

--- a/Roles/Neutral/PlatonicLover.cs
+++ b/Roles/Neutral/PlatonicLover.cs
@@ -17,7 +17,8 @@ public sealed class PlatonicLover : RoleBase, IKiller
             60400,
             SetupOptionItem,
             "純愛者",
-            "#ff6be4"
+            "#ff6be4",
+            true
         );
     public PlatonicLover(PlayerControl player)
     : base(

--- a/Roles/Neutral/Totocalcio.cs
+++ b/Roles/Neutral/Totocalcio.cs
@@ -17,7 +17,8 @@ public sealed class Totocalcio : RoleBase, IKiller, IAdditionalWinner
             60600,
             SetupOptionItem,
             "トトカルチョ",
-            "#00ff00"
+            "#00ff00",
+            true
         );
     public Totocalcio(PlayerControl player)
     : base(

--- a/main.cs
+++ b/main.cs
@@ -127,6 +127,8 @@ namespace TownOfHostY
 
         public static Main Instance;
 
+        public static int tempImpostorNum = 0;
+
         public override void Load()
         {
             Instance = this;


### PR DESCRIPTION
暗転、はぐれ狼の問題対応
・ジャッカル、アーソニストが死亡した会議後に暗転する問題対応
・Desync役職が死亡した会議後に暗転する問題対応
・はぐれ狼をインポスター数に含める
・ホストがはぐれ狼の場合のキルボタン制御