### PR TITLE
bugfix)ホスト死亡時のカスタムチャットメッセージ不具合

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -607,6 +607,8 @@ namespace TownOfHostY
             Logger.Info($"SendName: {SendName.RemoveHtmlTags()}, sender: {sender?.name}, sendTo: {sendTo}", "SendCustomChat");
             string command = "\n\n";
             if (sender == null) sender = PlayerControl.LocalPlayer;
+            if (sender.Data.IsDead)
+                sender = PlayerControl.AllPlayerControls.ToArray().OrderBy(x => x.PlayerId).Where(x => !x.Data.IsDead).FirstOrDefault();
             string name = sender.Data?.PlayerName;
             int clientId = sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
             if (clientId == -1)


### PR DESCRIPTION
ホストが死亡したときカスタムチャットメッセージが霊界メッセージになる問題対応