### PR TITLE
feature 設定 クライアントの「生き残り」モード追加

### DIFF
--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -791,6 +791,7 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "JClientAfterJackalDead","Client Mode After Jackal Dead","クライアントのジャッカル死亡後モード",,,,
 "JClientAfterJackalDeadMode.None","None","なし",,,,
 "JClientAfterJackalDeadMode.Following","Following","後追い",,,,
+"JClientAfterJackalDeadMode.Survival","Survive (3 or less)","生き残り(3人以下)","","","",""
 "LawyerTargetKnows","Lawyer target knows","依頼人は弁護されている事がわかる","律师的客户知道自己有律师",
 "LawyerKnowTargetRole","Lawyer know target role","弁護士は依頼人の役職が分かる","律师知道客户职业",
 "PursuerGuardNum","Pursuer guard count","追跡者のキルガード回数","起诉人自保次数",

--- a/Roles/Neutral/JClient.cs
+++ b/Roles/Neutral/JClient.cs
@@ -2,9 +2,10 @@ using System.Linq;
 using AmongUs.GameOptions;
 
 using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Interfaces;
 
 namespace TownOfHostY.Roles.Neutral;
-public sealed class JClient : RoleBase
+public sealed class JClient : RoleBase, IAdditionalWinner
 {
     public static readonly SimpleRoleInfo RoleInfo =
         SimpleRoleInfo.Create(
@@ -71,12 +72,14 @@ public sealed class JClient : RoleBase
     public enum AfterJackalDeadMode
     {
         None,
-        Following
+        Following,
+        Survival
     };
     private static readonly string[] AfterJackalDeadModeText =
     {
-    "JClientAfterJackalDeadMode.None",
-    "JClientAfterJackalDeadMode.Following",
+        "JClientAfterJackalDeadMode.None",
+        "JClientAfterJackalDeadMode.Following",
+        "JClientAfterJackalDeadMode.Survival",
     };
     public override void ApplyGameOptions(IGameOptions opt)
     {
@@ -129,5 +132,16 @@ public sealed class JClient : RoleBase
                 Logger.Info($"followingDead set:{Player.name}", "JClientDeadMode");
             }
         }
+    }
+    public bool CheckWin(out AdditionalWinners winnerType)
+    {
+        winnerType = AdditionalWinners.JClient;
+
+        if (AfterJackalDead != AfterJackalDeadMode.Survival) return false;
+        if (Player == null || !Player.IsAlive()) return false;
+        if (Main.AllAlivePlayerControls.ToArray().Any(pc => pc.Is(CustomRoles.Jackal))) return false;
+        if (Main.AllAlivePlayerControls.Count() > 3) return false;
+
+        return true;
     }
 }

--- a/main.cs
+++ b/main.cs
@@ -322,6 +322,7 @@ namespace TownOfHostY
         Totocalcio = CustomRoles.Totocalcio,
         Duelist = CustomRoles.Duelist,
         Archenemy = CustomRoles.Archenemy,
+        JClient = CustomRoles.JClient,
         HASFox = CustomRoles.HASFox,
         //CC
         RedC = CustomRoles.CCRedCat,


### PR DESCRIPTION
役職 クライアントのジャッカル死亡後モードに「生き残り」モードを追加

「生き残り」モード
ジャッカルが死亡後、ゲーム終了時にクライアントが生存しており、
全体の生存人数が３人以下の場合、クライアントが追加勝利

効果
・ジャッカルが死亡後のクライアントがすることがなく雑音になるのを避ける
・後追いの場合ジャッカル死亡が透けて狼有利になる場合があるのでその防止

クライアントはジャッカルへの暗殺の依頼人なので、
3人まで減らせられれば目的を達成できていると考えました
裏切りのリスクはあります・・・