### PR TITLE
20231024アップデート関連不具合の修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1080,6 +1080,8 @@ namespace TownOfHostY
             //ミーティング中の呼び出しは不正
             if (GameStates.IsMeeting) return;
 
+            if (MushroomMixupUpdateSystemPatch.InSabotageName) return; //キノコカオス中は無効
+
             var caller = new System.Diagnostics.StackFrame(1, false);
             var callerMethod = caller.GetMethod();
             string callerMethodName = callerMethod.Name;

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -50,6 +50,7 @@ public static class MeetingHudPatch
         public static void Prefix()
         {
             Logger.Info("------------会議開始------------", "Phase");
+            VentilationSystemPatch.ClearVent();
             ChatUpdatePatch.DoBlockChat = true;
             GameStates.AlreadyDied |= !Utils.IsAllAlive;
             Main.AllPlayerControls.Do(x => ReportDeadBodyPatch.WaitReport[x.PlayerId].Clear());

--- a/Patches/MushroomMixupSabotageSystemPatch.cs
+++ b/Patches/MushroomMixupSabotageSystemPatch.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Hazel;
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Interfaces;
+
+namespace TownOfHostY;
+
+[HarmonyPatch(typeof(MushroomMixupSabotageSystem), nameof(MushroomMixupSabotageSystem.UpdateSystem))]
+public static class MushroomMixupUpdateSystemPatch
+{
+    public static List<PlayerControl> TargetPlayers = new();
+    public static List<PlayerControl> ChangedPlayers = new();
+    public static void Prefix(MushroomMixupSabotageSystem __instance, PlayerControl player, MessageReader msgReader)
+    {
+        TargetPlayers.Clear();
+        ChangedPlayers.Clear();
+        foreach (PlayerControl pc in Main.AllAlivePlayerControls)
+        {
+            TargetPlayers.Add(pc);
+        }
+
+        foreach (PlayerControl pc in Main.AllAlivePlayerControls)
+        {
+            var role = pc.GetRoleClass();
+            if (role is IKiller && role is not IImpostor &&
+                !pc.Is(CustomRoles.Egoist))
+            {
+                ChangedPlayers.Add(pc);
+                foreach (PlayerControl target in TargetPlayers)
+                {
+                    target.RpcSetNamePrivate("<color=#00000000>.", seer: pc, force: true);
+                }
+            }
+        }
+    }
+}
+[HarmonyPatch(typeof(MushroomMixupSabotageSystem), nameof(MushroomMixupSabotageSystem.Deteriorate))]
+public static class MushroomMixupDeterioratePatch
+{
+    public static void Prefix(MushroomMixupSabotageSystem __instance, float deltaTime)
+    {
+        if (!__instance.IsActive) return;
+        if ((double)__instance.currentSecondsUntilHeal - deltaTime > 0.0) return;
+
+        foreach (var changed in MushroomMixupUpdateSystemPatch.ChangedPlayers.Where(x => x != null))
+        {
+            foreach (var target in MushroomMixupUpdateSystemPatch.TargetPlayers.Where(x => x != null))
+            {
+                target.RpcSetNamePrivate(Main.AllPlayerNames[target.PlayerId], seer: changed, force: true);
+            }
+        }
+        Utils.NotifyRoles();
+    }
+}
+

--- a/Patches/MushroomMixupSabotageSystemPatch.cs
+++ b/Patches/MushroomMixupSabotageSystemPatch.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using Hazel;
 using TownOfHostY.Roles.Core;
 using TownOfHostY.Roles.Core.Interfaces;
+using TownOfHostY.Roles.Neutral;
 
 namespace TownOfHostY;
 
@@ -25,7 +26,8 @@ public static class MushroomMixupUpdateSystemPatch
         {
             var role = pc.GetRoleClass();
             if (role is IKiller && role is not IImpostor &&
-                !pc.Is(CustomRoles.Egoist))
+                !pc.Is(CustomRoles.Egoist) &&
+                !(pc.Is(CustomRoles.Jackal) && Jackal.CanSeeNameMushroomMixup))
             {
                 ChangedPlayers.Add(pc);
                 foreach (PlayerControl target in TargetPlayers)

--- a/Patches/MushroomMixupSabotageSystemPatch.cs
+++ b/Patches/MushroomMixupSabotageSystemPatch.cs
@@ -11,6 +11,9 @@ namespace TownOfHostY;
 [HarmonyPatch(typeof(MushroomMixupSabotageSystem), nameof(MushroomMixupSabotageSystem.UpdateSystem))]
 public static class MushroomMixupUpdateSystemPatch
 {
+    public static bool InSabotageName => instance != null && instance.IsActive && NameChanged;
+    public static bool NameChanged = false;
+    private static MushroomMixupSabotageSystem instance;
     public static List<PlayerControl> TargetPlayers = new();
     public static List<PlayerControl> ChangedPlayers = new();
     public static void Prefix(MushroomMixupSabotageSystem __instance, PlayerControl player, MessageReader msgReader)
@@ -45,6 +48,8 @@ public static class MushroomMixupUpdateSystemPatch
                 }
             }
         }
+        instance = __instance;
+        NameChanged = true;
     }
 }
 [HarmonyPatch(typeof(MushroomMixupSabotageSystem), nameof(MushroomMixupSabotageSystem.Deteriorate))]
@@ -79,6 +84,7 @@ public static class MushroomMixupDeterioratePatch
 
         MushroomMixupUpdateSystemPatch.TargetPlayers.Clear();
         MushroomMixupUpdateSystemPatch.ChangedPlayers.Clear();
+        MushroomMixupUpdateSystemPatch.NameChanged = false;
 
         if (lateTask)
         {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -289,6 +289,7 @@ namespace TownOfHostY
             //=============================================
             //以下、ボタンが押されることが確定したものとする。
             //=============================================
+            MushroomMixupDeterioratePatch.RestorName();
 
             foreach (var role in CustomRoleManager.AllActiveRoles.Values)
             {

--- a/Patches/VentilationSystemPatch.cs
+++ b/Patches/VentilationSystemPatch.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using Hazel;
+
+namespace TownOfHostY;
+
+[HarmonyPatch(typeof(VentilationSystem), nameof(VentilationSystem.UpdateSystem))]
+class VentilationSystemPatch
+{
+    private static VentilationSystem Instance;
+    public static void Postfix(VentilationSystem __instance, PlayerControl player, MessageReader msgReader)
+    {
+        Instance = __instance;
+    }
+    public static void ClearVent()
+    {
+        if (Instance == null) return;
+
+        List<(byte playerId, byte ventId)> list = new();
+        foreach (var vent in Instance.PlayersInsideVents)
+        {
+            list.Add((vent.Key, vent.Value));
+        }
+
+        foreach (var vent in list)
+        {
+            var player = Utils.GetPlayerById(vent.playerId);
+            Logger.Info($"ClearVent player: {player?.name}, vent: {vent.ventId}", "VentilationSystem");
+            player?.MyPhysics.RpcExitVent(vent.ventId);
+        }
+    }
+}

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -803,6 +803,7 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "TotocalcioBetChangeCount","'BET'Change Count","「賭ける」の変更できる回数",
 "TotocalcioInitialCoolDown","'BET'Initial Ability Cooldown","「賭ける」の初期クールタイム",
 "TotocalcioFinalCoolDown","'BET'Final Ability Cooldown","「賭ける」の最終クールタイム",
+"JackalCanSeeNameMushroomMixup","Can See Name in MushroomMixup","キノコカオス中に名前が見える",,,,
 "JClientCanVent","Client Can Vent","クライアントがベントを使える",,,,
 "JClientImpostorVision","Client Impostor Vision","クライアントがインポスター視界を持つ",,,,
 "JClientVentCooldown","Client Vent Cooldown","クライアントのベントクールダウン",,,,

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -33,16 +33,23 @@ namespace TownOfHostY.Roles.Neutral
             CanVent = OptionCanVent.GetBool();
             CanUseSabotage = OptionCanUseSabotage.GetBool();
             HasImpostorVision = OptionHasImpostorVision.GetBool();
+            CanSeeNameMushroomMixup = OptionCanSeeNameMushroomMixup.GetBool();
         }
 
         private static OptionItem OptionKillCooldown;
         public static OptionItem OptionCanVent;
         public static OptionItem OptionCanUseSabotage;
         private static OptionItem OptionHasImpostorVision;
+        private static OptionItem OptionCanSeeNameMushroomMixup;
+        enum OptionName
+        {
+            JackalCanSeeNameMushroomMixup,
+        }
         private static float KillCooldown;
         public static bool CanVent;
         public static bool CanUseSabotage;
         private static bool HasImpostorVision;
+        public static bool CanSeeNameMushroomMixup;
 
         public SchrodingerCat.TeamType SchrodingerCatChangeTo => SchrodingerCat.TeamType.Jackal;
 
@@ -53,6 +60,7 @@ namespace TownOfHostY.Roles.Neutral
             OptionCanVent = BooleanOptionItem.Create(RoleInfo, 11, GeneralOption.CanVent, true, false);
             OptionCanUseSabotage = BooleanOptionItem.Create(RoleInfo, 12, GeneralOption.CanUseSabotage, false, false);
             OptionHasImpostorVision = BooleanOptionItem.Create(RoleInfo, 13, GeneralOption.ImpostorVision, true, false);
+            OptionCanSeeNameMushroomMixup = BooleanOptionItem.Create(RoleInfo, 14, OptionName.JackalCanSeeNameMushroomMixup, true, false);
             Options.SetUpAddOnOptions(RoleInfo.ConfigId + 20, RoleInfo.RoleName, RoleInfo.Tab);
         }
         public float CalculateKillCooldown() => KillCooldown;


### PR DESCRIPTION
20231024アップデート関連不具合の修正

不具合対応
・ベント内で会議になった場合にベント情報が残ってしまう問題修正
・キノコカオスサボタージュ中にDesync役職から名前が見えてしまう問題対応

追加設定
・ジャッカルがキノコカオスサボタージュ中に名前が見える設定を追加