### PR TITLE
bugfix vanilla)ベント内で会議になった場合にベント情報が残ってしまう問題修正（訂正版）

### DIFF
--- a/Patches/VentilationSystemPatch.cs
+++ b/Patches/VentilationSystemPatch.cs
@@ -1,32 +1,13 @@
-using System.Collections.Generic;
-using HarmonyLib;
-using Hazel;
 
 namespace TownOfHostY;
 
-[HarmonyPatch(typeof(VentilationSystem), nameof(VentilationSystem.UpdateSystem))]
 class VentilationSystemPatch
 {
-    private static VentilationSystem Instance;
-    public static void Postfix(VentilationSystem __instance, PlayerControl player, MessageReader msgReader)
-    {
-        Instance = __instance;
-    }
     public static void ClearVent()
     {
-        if (Instance == null) return;
-
-        List<(byte playerId, byte ventId)> list = new();
-        foreach (var vent in Instance.PlayersInsideVents)
-        {
-            list.Add((vent.Key, vent.Value));
-        }
-
-        foreach (var vent in list)
-        {
-            var player = Utils.GetPlayerById(vent.playerId);
-            Logger.Info($"ClearVent player: {player?.name}, vent: {vent.ventId}", "VentilationSystem");
-            player?.MyPhysics.RpcExitVent(vent.ventId);
-        }
+        if (!ShipStatus.Instance.Systems.TryGetValue(SystemTypes.Ventilation, out var systemType)) return;
+        var instance = systemType.Cast<VentilationSystem>();
+        instance.PlayersInsideVents.Clear();
+        instance.IsDirty = true;
     }
 }


### PR DESCRIPTION
ベント情報が残ってしまう問題修正の訂正

不具合対応
・ベント内で会議になった場合にベント情報が残ってしまう問題修正
・ホストがベント中に会議になった場合、湧き位置がベント位置になってしまう不具合対応