### PR TITLE
bugFix)トトカルチョの勝利条件判定の変更

### DIFF
--- a/Roles/Neutral/Y/Totocalcio.cs
+++ b/Roles/Neutral/Y/Totocalcio.cs
@@ -65,7 +65,14 @@ public sealed class Totocalcio : RoleBase, IKiller, IAdditionalWinner
 
     public bool CheckWin(ref CustomRoles winnerRole)
     {
-        return Player.IsAlive() && CustomWinnerHolder.WinnerIds.Contains(BetTarget.PlayerId);
+        if (!Player.IsAlive()) return false;
+        if (BetTarget == null) return false;
+
+        //トトカルチョ→トトカルチョの勝利連鎖は行わない
+        if (BetTarget.Is(CustomRoles.Totocalcio)) return false;
+
+        return CustomWinnerHolder.WinnerIds.Contains(BetTarget.PlayerId) ||
+               CustomWinnerHolder.WinnerRoles.Any(team => BetTarget.Is(team));
     }
     public override void Add()
     {


### PR DESCRIPTION
トトカルチョの勝利条件判定の変更
・ターゲット未選択時にエラーとなる不具合対応
・ターゲットがチーム勝利の場合に勝利できない不具合対応
・ターゲットがトトカルチョの場合に勝ち/負けがId順による問題対応
　⇒ターゲットがトトカルチョの場合は負け判定とする