### PR TITLE
役職 ゲッサー（イビルゲッサー、ナイスゲッサー、マッドゲッサー）の追加

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -588,6 +588,7 @@ namespace TownOfHostY
                     Prefix = mafia.CanUseKillButton() ? "After" : "Before";
                     break;
                 case CustomRoles.MadSnitch:
+                case CustomRoles.MadGuesser:
                 case CustomRoles.MadGuardian:
                     if (InfoLong) break;
                     text = CustomRoles.Madmate.ToString();

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -379,6 +379,25 @@ namespace TownOfHostY
             }
             return !canceled;
         }
+        public static void SendCustomChat(string SendName, string command, string name, PlayerControl sender = null)
+        {
+            Logger.Info($"SendCustomChat SendName: {SendName}, command: {command}, name: {name} sender: {sender?.name}", "SendCustomChat");
+            if (sender == null) sender = PlayerControl.LocalPlayer;
+            var crs = CustomRpcSender.Create("AllSend");
+            crs.AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
+                .Write(SendName)
+                .EndRpc()
+                .AutoStartRpc(sender.NetId, (byte)RpcCalls.SendChat)
+                .Write(command)
+                .EndRpc()
+                .AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
+                .Write(name)
+                .EndRpc()
+                .SendMessage();
+            sender.SetName(SendName);
+            DestroyableSingleton<HudManager>.Instance.Chat.AddChat(sender, command);
+            sender.SetName(name);
+        }
 
         public static void GetRolesInfo(string role)
         {
@@ -557,8 +576,8 @@ namespace TownOfHostY
 
                 default:
                     break;
-            }
         }
+    }
     }
     [HarmonyPatch(typeof(ChatController), nameof(ChatController.Update))]
     class ChatUpdatePatch

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -1132,6 +1132,8 @@ PanAlive25,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "Message.ExportedOptions","Exported options","オプションデータを出力しました","","","",""
 "Message.LoadedOptions","Loaded options","オプションデータを読み込みました","","","",""
 "Message.OnlyHostCanLoadOptions","Only the host can load options","ホストのみがオプションを読み込めます","","","",""
+"Message.SelfVoteForActivate","Vote yourself to activate the ability.","能力を発動するには自投票を行ってください","","","",""
+"Message.SelfVoteUsed","Ability used. The ability cannot be activated.","能力使用済み 能力を発動することはできません","","","",""
 "Message.NextPage","Next page","次ページ","","","",""
 
 "## 警告"

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -1137,6 +1137,8 @@ PanAlive25,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "Message.GuesserSelectionCancel","【Cancel Guesser Selection】\Guesser selection mode has been canceled.","【ゲッサーモード解除】\nゲッサーモードが解除されました","","","",""
 "Message.GuesserSelectionTarget","【Guesser Selection】\nSelect by voting the target.\n*Skip to cancel Guesser selection mode.\n\nTarget choice","【ゲッサー選択】\nターゲットを投票によって選択してください\n※スキップでゲッサーモード解除\n\nターゲットの選択","","","",""
 "Message.GuesserSelectionRole","【Guesser Selection】\nSelect by voting the target role.\nSelect by the number on the nameplate.\n*Skip to cancel Guesser selection mode.\nTarget: {0}\n\nRole choice(page {1}){2}","【ゲッサー選択】\nターゲットの役職を投票によって選択してください\nネームプレートにある番号で選択してください\n※スキップでゲッサーモード解除\nターゲット：{0}\n\n役職の選択(ページ{1}){2}","","","",""
+"Message.GuesserAbilityUse","【Guesser Kill】\nGuesser's ability activated","【ゲッサー】\nゲッサーの能力が発動されました","","","",""
+"Message.GuesserDead","died","が死亡しました","","","",""
 "Message.NextPage","Next page","次ページ","","","",""
 
 "## 警告"

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -1132,6 +1132,7 @@ PanAlive25,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "Message.ExportedOptions","Exported options","オプションデータを出力しました","","","",""
 "Message.LoadedOptions","Loaded options","オプションデータを読み込みました","","","",""
 "Message.OnlyHostCanLoadOptions","Only the host can load options","ホストのみがオプションを読み込めます","","","",""
+"Message.NextPage","Next page","次ページ","","","",""
 
 "## 警告"
 "Warning.EgoistCannotWin","Egoist cannot win","エゴイストが勝利できません","野心家无法获胜","利己主義者無法獲勝","Эгоист не может победить!","Egoísta não pode vencer"

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -151,6 +151,7 @@
 "MadNimrod","Mad Nimrod","マッドニムロッド",
 "MadScientist","Mad Scientist","マッド科学者",
 "MadJester","Mad Jester","マッドジェスター"
+"MadGuesser","Mad Guesser","マッドゲッサー","","","",""
 "SKMadmate","Sidekick Madmate","サイドキックマッドメイト","叛徒跟班","叛徒跟班","Союзник Безумца","Tripulante Louco Ajudante"
 
 "MadmateInfo","Help the Impostors","インポスターの援助をしよう","帮助内鬼","幫助偽裝者","Помогите Предателям","Ajude os Impostores"
@@ -164,6 +165,7 @@
 "MadNimrodInfo","Help the Impostors","インポスターの援助をしよう","帮助内鬼",,
 "MadScientistInfo","Help the Impostors","インポスターの援助をしよう","帮助内鬼",,
 "MadJesterInfo","Help the Impostors","インポスターの援助をしよう","帮助内鬼",,
+"MadGuesserInfo","Guess the Player Role","役職を推測しよう","","","",""
 "SKMadmateInfo","You are now on Team Impostors","サイドキックにされた","你是内鬼的好帮手","你現在是偽裝者的夥伴了，盡你所能幫助他們","Теперь вы в команде Предателя","Você agora está no Time Impostor"
 
 "MadmateInfoLong","(Impostors):\nYou are a crewmate, but you act as the impostors' ally.\nYou and the impostors cannot recognize each other.\nYou can vent, and you have no tasks.","(インポスター陣営):\nクルーだがインポスターの味方をする。\nインポスターと互いに認識できない。\nベントが使え、タスクはない。","(内鬼阵营):\n叛徒伪装成船员来帮助内鬼阵营，但是他们并不知道谁是内鬼。\n叛徒不可以进行击杀或者破坏，可以跳管道且没有任务。","(狼人陣營):\n船員,但是他們屬於狼人陣營.\n狼人無法知道叛徒是誰,\n他可以跳洞且沒有任務。","(Предатель):\nЧлен Экипажа, который на стороне Предателей. \nНо он не знает кто является Предателем в игре. \nМожет использовать вентиляцию, но нет заданий.","(Impostores):\nVocê é um tripulante que se aliou ao impostor.\nOs Impostores não sabem quem você é e vice-versa.\nPode usar a ventilação, e não tem tarefas."
@@ -176,6 +178,7 @@
 "MadNimrodInfoLong","(Impostors)\nCrewmate but takes the side of the Imposter. Unrecognizable to the Imposter and each other. no tasks. \nWhen Nimrod is exiled, a meeting is held again for a vote on Nimrod. Here, only Nimrod is allowed to discuss the matter once exiled, and he may choose one person to be voted in and executed along the way.","[インポスター陣営]:\nクルーだがインポスターの味方をする。インポスターと互いに認識できない。タスクはない。\n自身が追放された時、再びニムロッド投票用の会議が開かれる。ここでは追放されたらニムロッド以外は議論するべからず。1人を投票で選択して道連れ処刑することができる。",
 "MadScientistInfoLong","(Impostors)\nCrewmate but takes the side of the Imposter. Unrecognizable to the Imposter and each other. no tasks. \nMadScientist have Vital.","[インポスター陣営]:\nクルーだがインポスターの味方をする。インポスターと互いに認識できない。タスクはない。\nバイタルを持つ。",
 "MadJesterInfoLong","(Impostors)\nCrewmate but takes the side of the Imposter. Unrecognizable to the Imposter and each other. no tasks. \nIf he himself is expelled, the Impostor team wins.","[インポスター陣営]:\nクルーだがインポスターの味方をする。インポスターと互いに認識できない。タスクはない。\n自身が追放されると、その時点でインポスター陣営の勝利になる。",
+"MadGuesserInfoLong","(Impostors):\nMadmate guessing the player's role.\nYou can kill a player during a meeting by guessing their role.","(インポスター陣営):\n特殊能力を持つマッドスニッチです。\n会議中に他のプレイヤーの役職を当てる事でそのプレイヤーを死亡させることができます。","","","",""
 "SKMadmateInfoLong","(Impostors):\nThe player closest to a Shapeshifter when they shapeshift will become a Sidekick Madmate. You have no tasks.","(インポスター陣営):\n変身した際に一番近かった人がなれる役職。タスクはない。","(内鬼阵营):\n一些内鬼职业变形时，其附近的与其距离最近的玩家的职业有概率转化为该职业。\n叛徒跟班与内鬼不互认。","(狼人陣營):\n當狼人變形時\n離狼人變形最近的一個人將有機率轉化為叛徒跟班\n他沒有任務,且叛徒跟班與狼人無法互相知道。","(Предатель):\nРоль, которую может занять ближайший к вам игрок, когда вы используете Морф. Нет заданий.","(Impostores):\nO jogador mais próximo de um Metamorfo quando eles se transformam virará um Tripulante Louco Ajudante. Você não tem tarefas."
 
 

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -1134,6 +1134,7 @@ PanAlive25,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "Message.OnlyHostCanLoadOptions","Only the host can load options","ホストのみがオプションを読み込めます","","","",""
 "Message.SelfVoteForActivate","Vote yourself to activate the ability.","能力を発動するには自投票を行ってください","","","",""
 "Message.SelfVoteUsed","Ability used. The ability cannot be activated.","能力使用済み 能力を発動することはできません","","","",""
+"Message.SelfVoteSuffix","Vote self to use","自投票で能力発動","","","",""
 "Message.GuesserSelectionCancel","【Cancel Guesser Selection】\Guesser selection mode has been canceled.","【ゲッサーモード解除】\nゲッサーモードが解除されました","","","",""
 "Message.GuesserSelectionTarget","【Guesser Selection】\nSelect by voting the target.\n*Skip to cancel Guesser selection mode.\n\nTarget choice","【ゲッサー選択】\nターゲットを投票によって選択してください\n※スキップでゲッサーモード解除\n\nターゲットの選択","","","",""
 "Message.GuesserSelectionRole","【Guesser Selection】\nSelect by voting the target role.\nSelect by the number on the nameplate.\n*Skip to cancel Guesser selection mode.\nTarget: {0}\n\nRole choice(page {1}){2}","【ゲッサー選択】\nターゲットの役職を投票によって選択してください\nネームプレートにある番号で選択してください\n※スキップでゲッサーモード解除\nターゲット：{0}\n\n役職の選択(ページ{1}){2}","","","",""

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -218,6 +218,7 @@
 "LoyalDoggy","Loyal Doggy","ロイヤルドギー",
 "Rabbit","Rabbit","ラビット",
 "VentManager","Vent Manager","ベントマネージャー",
+"NiceGuesser","Nice Guesser","ナイスゲッサー","","","",""
 
 "CustomCrewmateInfo","I can now use abilities like that.","あんな能力も使えるようになりました。",
 "NiceWatcherInfo","Gaze upon all votes","みんなの投票に目を光らせよう","你可以看见所有人的投票，注意他们的选择","注意所有人的投票","Вы видите цвета голосов","Veja todos os votos"
@@ -255,6 +256,7 @@
 "LoyalDoggyInfo","How are you doing? Master!","調子はどうですか？ご主人様！",
 "RabbitInfo","I have a good ear, so.","耳がいいので探知できるんだ",
 "VentManagerInfo","Vent,Vent,Vent!","ベント、ベント、ベント！",
+"NiceGuesserInfo","Guess the Player Role","役職を推測しよう","","","",""
 
 "CustomCrewmateInfoLong","(Crewmates):\Crewmate with the ability to Add-On to attributes set by the host.","[クルー陣営]\nホストによって設定された属性の能力をもつクルーメイト。",
 "NiceWatcherInfoLong","(Crewmates):\nYou can see everyone's votes even if anonymous voting is on.","(クルー陣営):\n全員の投票先を見ることができる。","(船员阵营:\n会议时窥视者可以看到所有人的投票。","(船員):\n會議時觀察者可以看到所有人的投票。","(Член Экипажа):\nNice Watcher может видеть все цвета голосов несмотря на анонимное голосование.","(Tripulantes):\nVocê consegue ver os votos de todos, mesmo que os votos anônimos estejam ligados."
@@ -292,7 +294,7 @@
 "LoyalDoggyInfoLong","(Crewmates)\nVote for one person of your choice at the very first meeting and nominate them as Master. (Votes are not shown).\nThe position of the master can be detected by the sense of smell. When the master is killed, the arrow will no longer be displayed. By setting, the task disappears after the Master's death.","[クルー陣営]\n一番初めの会議で1人好きな人に投票して、ご主人として指名する。(票は表示されない)\nその人の場所を嗅覚により探知できる。ご主人がキルされた時、ご主人への矢印はなくなる。設定により、ご主人の死亡後はタスクが無くなる。",
 "RabbitInfoLong","(Crewmates)\nWhen a set number of tasks are completed, an arrow will indicate for 5 seconds in which direction a random 1 Impostor is at that time for each task completed.\nEven after all tasks have been completed, uncounted tasks will appear and the ability will be available for each completed task.","[クルー陣営]\n設定タスク完了すると、タスクを1つ完了させる毎にその時のランダムな1インポスターがどの方向にいるかが矢印で5秒間表示される。\nタスク全完了後もカウントされないタスクが発生し、完了するごとに能力を使用できる。",
 "VentManagerInfoLong","(Crewmates)\nClean Vent.","[クルー陣営]\nベントを掃除しよう。ただそれだけ。",
-
+"NiceGuesserInfoLong","(Crewmates):\nCrewmate guessing the player's role.\nYou can kill a player during a meeting by guessing their role.","(クルー陣営):\n特殊能力を持つクルーメイトです。\n会議中に他のプレイヤーの役職を当てる事でそのプレイヤーを死亡させることができます。","","","",""
 
 "# ニュートラル役職"
 "Jester","Jester","ジェスター","小丑","小丑","Шут","Bobo"

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -1134,6 +1134,9 @@ PanAlive25,\nBread was served by the bakery.\nㅤ,\nパン屋は{0}に向けて�
 "Message.OnlyHostCanLoadOptions","Only the host can load options","ホストのみがオプションを読み込めます","","","",""
 "Message.SelfVoteForActivate","Vote yourself to activate the ability.","能力を発動するには自投票を行ってください","","","",""
 "Message.SelfVoteUsed","Ability used. The ability cannot be activated.","能力使用済み 能力を発動することはできません","","","",""
+"Message.GuesserSelectionCancel","【Cancel Guesser Selection】\Guesser selection mode has been canceled.","【ゲッサーモード解除】\nゲッサーモードが解除されました","","","",""
+"Message.GuesserSelectionTarget","【Guesser Selection】\nSelect by voting the target.\n*Skip to cancel Guesser selection mode.\n\nTarget choice","【ゲッサー選択】\nターゲットを投票によって選択してください\n※スキップでゲッサーモード解除\n\nターゲットの選択","","","",""
+"Message.GuesserSelectionRole","【Guesser Selection】\nSelect by voting the target role.\nSelect by the number on the nameplate.\n*Skip to cancel Guesser selection mode.\nTarget: {0}\n\nRole choice(page {1}){2}","【ゲッサー選択】\nターゲットの役職を投票によって選択してください\nネームプレートにある番号で選択してください\n※スキップでゲッサーモード解除\nターゲット：{0}\n\n役職の選択(ページ{1}){2}","","","",""
 "Message.NextPage","Next page","次ページ","","","",""
 
 "## 警告"

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -46,6 +46,7 @@
 "Escalationer","Escalationer","エスカレーショナー",
 "EvilDyer","Evil Dyer","イビル真っ赤",
 "BestieWolf","Bestie Wolf","ベスティーウルフ",
+"EvilGuesser","Evil Guesser","イビルゲッサー","","","",""
 
 "CustomImpostorInfo","I can now use abilities like that","あんな能力も使えるようになりました",
 "EvilWatcherInfo","Gaze upon all votes","みんなの投票に目を光らせよう","你可以看见所有人的投票，注意他们的选择","注意所有人的投票","Вы видите цвета голосов","Veja todos os votos"
@@ -79,6 +80,7 @@
 "EvilDyerInfo","Let's going to dye them all red","皆を赤色に染めてやるんだ",
 "BestieWolfInfo","I'll be in support","うちはサポートにまわります",
 "AfterBestieWolfInfo","I lost my friends, why..?","仲間おらんなった、、なんで、、",
+"EvilGuesserInfo","Guess the Player Role","役職を推測しよう","","","",""
 
 "CustomImpostorInfoLong","(Impostors):\nImpostor with the ability to Add-On to attributes set by the host.","[インポスター陣営]\nホストによって設定された属性の能力をもつインポスター。",
 "EvilWatcherInfoLong","(Impostors):\nYou can see everyone's votes even if anonymous voting is on.","(インポスター陣営):\n全員の投票先を見ることができる。","(内鬼阵营):\n会议时窥视者可以看到所有人的投票。","(狼人陣營):\n會議時觀察者可以看到所有人的投票。","(Предатель):\nNice Watcher может видеть все цвета голосов несмотря на анонимное голосование.","(Impostores):\nVocê consegue ver os votos de todos, mesmo que os votos anônimos estejam ligados."
@@ -109,6 +111,7 @@
 "EscalationerInfoLong","(Impostors):\nWhen Escalationer kills, everyone's player speed increases.In addition, the killcool is shortened for each kill only for himself.","[インポスター陣営]\n自身がキルすると、全員のプレイヤースピードが上昇する。また、自身のみキルする度にキルクールが短くなる。",
 "EvilDyerInfoLong","(Impostors):\nWhen he kills someone, everyone turns red for a certain period of time.","[インポスター陣営]\n自身が誰かキルすると全員が一定時間、赤色の姿になる。",
 "BestieWolfInfoLong","(Impostors):\nHe is supportive of his partner because of his love for his companions, but when he becomes a lone Impostor, he becomes lonely and goes berserk.\n\nWhen multiple Impostors are alive, the buff Add-On is given to the partner Impostor depending on the number of kills.\nIf you are the sole Impostor and there is someone else within view of the kill target at the time of the kill, you will kill that person at the same time. Additional kills are limited to one person per kill, and when simultaneous kills occur, a kill flash is visible from all viewpoints.","[インポスター陣営]\n仲間想いなため相方へのサポートをするが、単独な狼になった時には孤独が寂しくなり暴走する。\n\n複数インポスターが生存時、キル回数によって相方インポスターにバフ属性を付与する。\n自身が単独インポスターになった場合、キルする時にそのキル対象の見える範囲内に誰かいた場合、その人まで同時にキルする。追加キルは1キル1人までで、同時キルが起こった時は全視点でキルフラッシュが見える。"
+"EvilGuesserInfoLong","(Impostors):\nImpostor guessing the player's role.\nYou can kill a player during a meeting by guessing their role.","(インポスター陣営):\n特殊能力を持つインポスターです。\n会議中に他のプレイヤーの役職を当てる事でそのプレイヤーを死亡させることができます。","","","",""
 
 #イビルハッカ
 "EvilHacker","Evil Replicator","イビルハッカー...?",
@@ -716,7 +719,8 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "RevengeNeutral","Can Revenge Neutrals","道連れ能力持ちがニュートラル役職を道連れ出来る","可以接受同伴为中立",,
 "RevengeMadByImpostor","Can Revenge Madmates By Impostor Team","道連れ能力持ちインポスター陣営がマッド系役職を道連れ出来る",,,
 "TaskTrigger","Trigger Tasks","能力が使用可能になるタスク数",
-
+"GuesserNumOfGuess","Num Of Guess","推測の回数","","","",""
+"GuesserMultipleInMeeting","Multiple In Meeting","１会議での複数使用","","","",""
 
 # インポスター
 "BountyTargetChangeTime","Time Until Target Swaps","ターゲット変更時間","赏金目标切换时间","賞金目標切換時間","Время смены цели","Tempo Para Troca de Alvos"

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -24,6 +24,7 @@ public abstract class VoteGuesser : RoleBase
         hasAbility)
     {
         NumOfGuess = 1;
+        MultipleInMeeting = false;
 
         guesserInfo = null;
 
@@ -34,6 +35,7 @@ public abstract class VoteGuesser : RoleBase
     }
 
     protected int NumOfGuess = 1;
+    protected bool MultipleInMeeting = false;
 
     private GuesserInfo guesserInfo;
 
@@ -66,7 +68,7 @@ public abstract class VoteGuesser : RoleBase
         if (Player == null) return true;
 
         if (NumOfGuess <= 0) return true;
-        if (guessed) return true;
+        if (guessed && !MultipleInMeeting) return true;
 
         if (selecting)
         {
@@ -179,7 +181,7 @@ public abstract class VoteGuesser : RoleBase
     }
     private void SendMessageGuide()
     {
-        if (NumOfGuess > 0 && !guessed)
+        if (NumOfGuess > 0 && (!guessed || MultipleInMeeting))
         {
             Utils.SendMessage(GetString("Message.SelfVoteForActivate"), Player.PlayerId);
         }

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace TownOfHostY.Roles.Core.Class;
+
+public abstract class VoteGuesser : RoleBase
+{
+    public VoteGuesser(
+        SimpleRoleInfo roleInfo,
+        PlayerControl player,
+        Func<HasTask> hasTasks = null,
+        bool? hasAbility = null
+    )
+    : base(
+        roleInfo,
+        player,
+        hasTasks,
+        hasAbility)
+    {
+    }
+}

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -221,6 +221,29 @@ public abstract class VoteGuesser : RoleBase
 
         guesserInfo = null;
     }
+    public override string GetSuffix(PlayerControl seer, PlayerControl seen = null, bool isForMeeting = false)
+    {
+        seen ??= seer;
+        if (!isForMeeting) return "";
+        if (seer == null || seen != seer) return "";
+        if (!seer.IsAlive()) return "";
+        if (NumOfGuess <= 0) return "";
+
+        if (guesserInfo == null) guesserInfo = new();
+
+        var mark = "";
+        var suffix = "";
+        if (seer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+        {
+            if (guesserInfo.PlayerNumbers.TryGetValue(seer.PlayerId, out int number))
+            {
+                mark = $"<color=#ff8000><size=110%>{number}</size></color>";
+            }
+            suffix = GetProgressText();
+        }
+
+        return $"{mark} <color=#ff8000><size=1.5>{GetString("Message.SelfVoteSuffix")}</size></color> {suffix}";
+    }
     public void RpcGuesserMurderPlayer(PlayerControl target, CustomDeathReason reason)
     {
         target.Data.IsDead = true;

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Collections.Generic;
+using UnityEngine;
 
 using static TownOfHostY.Translator;
 
@@ -21,8 +22,12 @@ public abstract class VoteGuesser : RoleBase
         hasTasks,
         hasAbility)
     {
+        NumOfGuess = 1;
     }
 
+    protected int NumOfGuess = 1;
+
+    public override string GetProgressText(bool comms = false) => Utils.ColorString(NumOfGuess > 0 ? Color.yellow : Color.gray, $"({NumOfGuess})");
     private class GuesserInfo
     {
         public Dictionary<byte, int> PlayerNumbers;

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Linq;
+using System.Text;
+using System.Collections.Generic;
+
+using static TownOfHostY.Translator;
 
 namespace TownOfHostY.Roles.Core.Class;
 
@@ -16,5 +21,121 @@ public abstract class VoteGuesser : RoleBase
         hasTasks,
         hasAbility)
     {
+    }
+
+    private class GuesserInfo
+    {
+        public Dictionary<byte, int> PlayerNumbers;
+        private List<CustomRoles> roleList;
+        private List<(PlayerControl target, int number, CustomRoles role)> dispList = new();
+
+        private int indexDisplayed = -1;
+        public int PageNo = 0;
+
+        public GuesserInfo()
+        {
+            SetPlayerNumbers();
+            SetRoleList();
+            SetDispList();
+        }
+        public void ResetList()
+        {
+            indexDisplayed = -1;
+            PageNo = 0;
+            SetDispList();
+        }
+        public void NextPage()
+        {
+            SetDispList();
+        }
+        private void SetPlayerNumbers()
+        {
+            PlayerNumbers = new();
+            var number = 1; //Numberは1始まり
+            foreach (var pc in Main.AllAlivePlayerControls.OrderBy(x => x.PlayerId))
+            {
+                PlayerNumbers.Add(pc.PlayerId, number++);
+            }
+        }
+        private void SetRoleList()
+        {
+            roleList = new();
+            foreach (CustomRoles role in CustomRolesHelper.AllStandardRoles.Where(r => r.IsEnable()))
+            {
+                if (role is CustomRoles.LastImpostor or CustomRoles.Lovers or CustomRoles.Workhorse) continue;
+                roleList.Add(role);
+            }
+        }
+        private void SetDispList()
+        {
+            CustomRoles role;
+            int index;
+            int indexRole;
+
+            dispList = new();
+
+            var targetList = Main.AllAlivePlayerControls.Where(x => !x.Data.Disconnected).OrderBy(x => x.PlayerId);
+
+            if (indexDisplayed >= roleList.Count - 1)
+            {
+                indexDisplayed = -1;
+                PageNo = 0;
+            }
+            PageNo++;
+            index = 0;
+            indexRole = indexDisplayed + index + 1;
+            foreach (var target in targetList)
+            {
+                if (!PlayerNumbers.TryGetValue(target.PlayerId, out int number)) continue;
+
+                if (index >= targetList.Count() - 1 && (PageNo > 1 || indexRole < roleList.Count - 1))
+                {
+                    //次ページ表示
+                    role = CustomRoles.DummyNext;
+                }
+                else if (indexRole >= roleList.Count)
+                {
+                    //無効分
+                    role = CustomRoles.NotAssigned;
+                }
+                else
+                {
+                    role = roleList[indexRole];
+                    indexDisplayed = indexRole;
+                }
+                dispList.Add((target, number, role));
+
+                index++;
+                indexRole++;
+            }
+        }
+        public string GetRoleGuide()
+        {
+            string text;
+
+            StringBuilder sb = new();
+            foreach (var info in dispList)
+            {
+                if (info.role == CustomRoles.NotAssigned) continue;
+
+                if (info.role == CustomRoles.DummyNext)
+                {
+                    text = $"\n{info.number} {GetString("Message.NextPage")}";
+                }
+                else
+                {
+                    text = $"\n{info.number} {Utils.GetRoleName(info.role)}";
+                }
+                sb.Append(text);
+                Logger.Info($"dispRole {text}", "Guesser.RoleText");
+            }
+            return sb.ToString();
+        }
+        public CustomRoles GetRole(PlayerControl target)
+        {
+            var info = dispList.FirstOrDefault(x => x.target == target);
+            if (info.target == null) return CustomRoles.NotAssigned;
+            return info.role;
+        }
     }
 }

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -25,11 +25,15 @@ public abstract class VoteGuesser : RoleBase
         NumOfGuess = 1;
 
         guesserInfo = null;
+
+        guessed = false;
     }
 
     protected int NumOfGuess = 1;
 
     private GuesserInfo guesserInfo;
+
+    private bool guessed = false;
 
     public override string GetProgressText(bool comms = false) => Utils.ColorString(NumOfGuess > 0 ? Color.yellow : Color.gray, $"({NumOfGuess})");
     public override void OverrideDisplayRoleNameAsSeer(PlayerControl seen, bool isMeeting, ref bool enabled, ref Color roleColor, ref string roleText)
@@ -49,6 +53,21 @@ public abstract class VoteGuesser : RoleBase
             enabled = true;
         }
         roleText = $"<color=#ffff00><size=110%>{number}</size></color>{roleText}";
+    }
+    private void SendMessageGuide()
+    {
+        if (NumOfGuess > 0 && !guessed)
+        {
+            Utils.SendMessage(GetString("Message.SelfVoteForActivate"), Player.PlayerId);
+        }
+        else
+        {
+            Utils.SendMessage(GetString("Message.SelfVoteUsed"), Player.PlayerId);
+        }
+    }
+    public override void OnStartMeeting()
+    {
+        SendMessageGuide();
     }
     private class GuesserInfo
     {

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -23,11 +23,33 @@ public abstract class VoteGuesser : RoleBase
         hasAbility)
     {
         NumOfGuess = 1;
+
+        guesserInfo = null;
     }
 
     protected int NumOfGuess = 1;
 
+    private GuesserInfo guesserInfo;
+
     public override string GetProgressText(bool comms = false) => Utils.ColorString(NumOfGuess > 0 ? Color.yellow : Color.gray, $"({NumOfGuess})");
+    public override void OverrideDisplayRoleNameAsSeer(PlayerControl seen, bool isMeeting, ref bool enabled, ref Color roleColor, ref string roleText)
+    {
+        if (!isMeeting) return;
+        if (Player == null || !Player.IsAlive()) return;
+        if (seen == null || !seen.IsAlive() || seen.Data.Disconnected) return;
+        if (NumOfGuess <= 0) return;
+
+        if (guesserInfo == null) guesserInfo = new();
+
+        if (!guesserInfo.PlayerNumbers.TryGetValue(seen.PlayerId, out int number)) return;
+
+        if (!enabled)
+        {
+            roleText = "";
+            enabled = true;
+        }
+        roleText = $"<color=#ffff00><size=110%>{number}</size></color>{roleText}";
+    }
     private class GuesserInfo
     {
         public Dictionary<byte, int> PlayerNumbers;

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -445,6 +445,7 @@ public enum CustomRoles
     Escalationer,
     EvilDyer,
     BestieWolf,
+    EvilGuesser,
     //Madmate
     MadGuardian,
     Madmate,

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -460,6 +460,7 @@ public enum CustomRoles
 
     MadDilemma,
     SKMadmate,
+    MadGuesser,
     //Crewmate(Vanilla)
     Engineer,
     GuardianAngel,

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -503,6 +503,7 @@ public enum CustomRoles
     Rabbit,
     VentManager,
     Counselor,
+    NiceGuesser, 
 
     Potentialist,
     //Neutral

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -588,6 +588,9 @@ public enum CustomRoles
     Archenemy,
 
     MaxAddon,
+
+    //dummy
+    DummyNext = 10000,
 }
 public enum CustomRoleTypes
 {

--- a/Roles/Crewmate/Y/NiceGuesser.cs
+++ b/Roles/Crewmate/Y/NiceGuesser.cs
@@ -1,0 +1,43 @@
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Class;
+
+namespace TownOfHostY.Roles.Crewmate;
+public sealed class NiceGuesser : VoteGuesser
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+         SimpleRoleInfo.Create(
+            typeof(NiceGuesser),
+            player => new NiceGuesser(player),
+            CustomRoles.NiceGuesser,
+            () => RoleTypes.Crewmate,
+            CustomRoleTypes.Crewmate,
+            (int)Options.offsetId.CrewY + 1900,
+            SetupOptionItem,
+            "ナイスゲッサー",
+            "#ffff00"
+        );
+    public NiceGuesser(PlayerControl player)
+    : base(
+        RoleInfo,
+        player
+    )
+    {
+        NumOfGuess = OptionNumOfGuess.GetInt();
+        MultipleInMeeting = OptionMultipleInMeeting.GetBool();
+    }
+    private static OptionItem OptionNumOfGuess;
+    private static OptionItem OptionMultipleInMeeting;
+    enum OptionName
+    {
+        GuesserNumOfGuess,
+        GuesserMultipleInMeeting,
+    }
+    public static void SetupOptionItem()
+    {
+        OptionNumOfGuess = IntegerOptionItem.Create(RoleInfo, 10, OptionName.GuesserNumOfGuess, new(1, 15, 1), 1, false)
+            .SetValueFormat(OptionFormat.Times);
+        OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 11, OptionName.GuesserMultipleInMeeting, false, false);
+    }
+}

--- a/Roles/Impostor/Y/EvilGuesser.cs
+++ b/Roles/Impostor/Y/EvilGuesser.cs
@@ -1,0 +1,42 @@
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Class;
+using TownOfHostY.Roles.Core.Interfaces;
+
+namespace TownOfHostY.Roles.Impostor;
+public sealed class EvilGuesser : VoteGuesser, IImpostor
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+         SimpleRoleInfo.Create(
+            typeof(EvilGuesser),
+            player => new EvilGuesser(player),
+            CustomRoles.EvilGuesser,
+            () => RoleTypes.Impostor,
+            CustomRoleTypes.Impostor,
+            (int)Options.offsetId.ImpY + 1400,
+            SetupOptionItem,
+            "イビルゲッサー"
+        );
+    public EvilGuesser(PlayerControl player)
+    : base(
+        RoleInfo,
+        player)
+    {
+        NumOfGuess = OptionNumOfGuess.GetInt();
+        MultipleInMeeting = OptionMultipleInMeeting.GetBool();
+    }
+    private static OptionItem OptionNumOfGuess;
+    private static OptionItem OptionMultipleInMeeting;
+    enum OptionName
+    {
+        GuesserNumOfGuess,
+        GuesserMultipleInMeeting,
+    }
+    public static void SetupOptionItem()
+    {
+        OptionNumOfGuess = IntegerOptionItem.Create(RoleInfo, 10, OptionName.GuesserNumOfGuess, new(1, 15, 1), 1, false)
+            .SetValueFormat(OptionFormat.Times);
+        OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 11, OptionName.GuesserMultipleInMeeting, false, false);
+    }
+}

--- a/Roles/Madmate/Y/MadGuesser.cs
+++ b/Roles/Madmate/Y/MadGuesser.cs
@@ -1,0 +1,118 @@
+using System.Linq;
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Class;
+using TownOfHostY.Roles.Core.Interfaces;
+
+namespace TownOfHostY.Roles.Madmate;
+
+public sealed class MadGuesser : VoteGuesser, IKillFlashSeeable, IDeathReasonSeeable
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+        SimpleRoleInfo.Create(
+            typeof(MadGuesser),
+            player => new MadGuesser(player),
+            CustomRoles.MadGuesser,
+            () => OptionCanVent.GetBool() ? RoleTypes.Engineer : RoleTypes.Crewmate,
+            CustomRoleTypes.Madmate,
+            (int)Options.offsetId.MadY + 500,
+            SetupOptionItem,
+            "マッドゲッサー",
+            introSound: () => GetIntroSound(RoleTypes.Impostor)
+        );
+    public MadGuesser(PlayerControl player)
+    : base(
+        RoleInfo,
+        player,
+        () => HasTask.ForRecompute)
+    {
+        CanSeeKillFlash = Options.MadmateCanSeeKillFlash.GetBool();
+        CanSeeDeathReason = Options.MadmateCanSeeDeathReason.GetBool();
+
+        CanVent = OptionCanVent.GetBool();
+        CanAlsoBeExposedToImpostor = OptionCanAlsoBeExposedToImpostor.GetBool();
+        TaskTrigger = OptionTaskTrigger.GetInt();
+
+        NumOfGuess = OptionNumOfGuess.GetInt();
+        MultipleInMeeting = OptionMultipleInMeeting.GetBool();
+
+        CustomRoleManager.MarkOthers.Add(GetMarkOthers);
+    }
+
+    private static OptionItem OptionCanVent;
+    private static OptionItem OptionCanAlsoBeExposedToImpostor;
+    private static OptionItem OptionNumOfGuess;
+    private static OptionItem OptionMultipleInMeeting;
+    /// <summary>能力発動タスク数</summary>
+    private static OptionItem OptionTaskTrigger;
+    private static Options.OverrideTasksData Tasks;
+    enum OptionName
+    {
+        CanVent,
+        MadSnitchCanAlsoBeExposedToImpostor,
+        MadSnitchTaskTrigger,
+        GuesserNumOfGuess,
+        GuesserMultipleInMeeting,
+    }
+    private static bool CanSeeKillFlash;
+    private static bool CanSeeDeathReason;
+    private static bool CanVent;
+    private static bool CanAlsoBeExposedToImpostor;
+    private static int TaskTrigger;
+
+    public static void SetupOptionItem()
+    {
+        OptionCanVent = BooleanOptionItem.Create(RoleInfo, 10, OptionName.CanVent, false, false);
+        OptionCanAlsoBeExposedToImpostor = BooleanOptionItem.Create(RoleInfo, 11, OptionName.MadSnitchCanAlsoBeExposedToImpostor, false, false);
+        OptionNumOfGuess = IntegerOptionItem.Create(RoleInfo, 13, OptionName.GuesserNumOfGuess, new(1, 15, 1), 1, false)
+            .SetValueFormat(OptionFormat.Times);
+        OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 14, OptionName.GuesserMultipleInMeeting, false, false);
+        OptionTaskTrigger = IntegerOptionItem.Create(RoleInfo, 12, OptionName.MadSnitchTaskTrigger, new(0, 99, 1), 1, false).SetValueFormat(OptionFormat.Pieces);
+        Tasks = Options.OverrideTasksData.Create(RoleInfo, 20);
+        Options.SetUpAddOnOptions(RoleInfo.ConfigId + 30, RoleInfo.RoleName, RoleInfo.Tab);
+    }
+
+    private bool KnowsImpostor()
+    {
+        return MyTaskState.HasCompletedEnoughCountOfTasks(TaskTrigger);
+    }
+    private void CheckAndAddNameColorToImpostors()
+    {
+        if (!KnowsImpostor()) return;
+
+        foreach (var impostor in Main.AllPlayerControls.Where(player => player.Is(CustomRoleTypes.Impostor)))
+        {
+            NameColorManager.Add(Player.PlayerId, impostor.PlayerId, impostor.GetRoleColorCode());
+        }
+    }
+    public override void Add()
+    {
+        CheckAndAddNameColorToImpostors();
+    }
+    public override bool OnCompleteTask()
+    {
+        CheckAndAddNameColorToImpostors();
+        return true;
+    }
+    public static string GetMarkOthers(PlayerControl seer, PlayerControl seen = null, bool isForMeeting = false)
+    {
+        seen ??= seer;
+        if (
+            // オプションが無効
+            !CanAlsoBeExposedToImpostor ||
+            // インポスター→MadGuesserではない
+            !seer.Is(CustomRoleTypes.Impostor) ||
+            seen.GetRoleClass() is not MadGuesser madGuesser ||
+            // マッドスニッチがまだインポスターを知らない
+            !madGuesser.KnowsImpostor())
+        {
+            return string.Empty;
+        }
+
+        return Utils.ColorString(Utils.GetRoleColor(CustomRoles.MadGuesser), "★");
+    }
+
+    public bool CheckKillFlash(MurderInfo info) => CanSeeKillFlash;
+    public bool CheckSeeDeathReason(PlayerControl seen) => CanSeeDeathReason;
+}


### PR DESCRIPTION
役職 ゲッサー（イビルゲッサー、ナイスゲッサー、マッドゲッサー）の追加

ゲッサー
　会議中に１人の役職を指定することで会議中キルができる。（死因：キル）
　役職が誤っていた場合は誤爆となる。（死因：誤爆）
　ゲッサーとして以下の３役職
　　イビルゲッサー（インポスター陣営）
　　　通常インポスター＋ゲッサー能力
　　ナイスゲッサー（クルー陣営）
　　　通常クルーメイト（タスクあり）＋ゲッサー能力
　　マッドゲッサー（マッドメイト、インポスター陣営）
　　　マッドスニッチ＋ゲッサー能力

設定（共通）
　１ゲーム中で推測できる回数
　１会議での複数回能力を使用できるかどうか
　※マッドゲッサーはマッドスニッチ継承設定があります

ゲッサー能力発動の仕方（共通）
　１，自分に投票します
　　⇒ゲッサー対象選択モードになり、操作方法がチャットに表示されます。
　２，ターゲットへ投票します
　　⇒役職選択モードになり、操作方法がチャットに表示されます。
　３，役職を投票により選択します
　　役職はチャットに表示された役職番号に該当する番号の人に投票します。（添付イメージ１，２参照）

イメージ１）役職番号のチャット表示
![image](https://github.com/Yumenopai/TownOfHost_Y/assets/112561720/2ad2e736-9d7a-40bd-ae84-805494bd49e3)
イメージ２）会議画面のネームプレート（番号表示）
![image](https://github.com/Yumenopai/TownOfHost_Y/assets/112561720/c80f43bf-529f-4c1c-8a46-49171b7a7de8)
