### PR TITLE
feature）ゲーム終了判定の人数として妖狐をカウントしない

### DIFF
--- a/Roles/Neutral/FoxSpirit/FoxSpirit.cs
+++ b/Roles/Neutral/FoxSpirit/FoxSpirit.cs
@@ -19,6 +19,7 @@ public sealed class FoxSpirit : RoleBase, ISystemTypeUpdateHook
             SetupOptionItem,
             "妖狐",
             "#ad6ce0",
+            countType: CountTypes.None,
             introSound: () => GetIntroSound(RoleTypes.Shapeshifter),
             assignInfo: new(CustomRoles.FoxSpirit, CustomRoleTypes.Neutral)
             {


### PR DESCRIPTION
仕様変更）ゲーム終了判定の人数として妖狐をカウントしない

移植役職のため本家TOR-GMに合わせての挙動変更
クルー１狼１狐１でゲームが硬直するのを防止するため