### PR TITLE
feature）役職 チェインシフター の追加

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -369,21 +369,31 @@ namespace TownOfHostY
         {
             return $"{player?.Data?.PlayerName}" + (GameStates.IsInGame ? $"({player?.GetAllRoleName()})" : "");
         }
-        public static string GetRoleColorCode(this PlayerControl player)
+        public static string GetRoleColorCode(this PlayerControl player, bool temporaryRole = false)
         {
+            var role = player.GetCustomRole();
+            if (temporaryRole)
+            {
+            }
+
             (Color c, string t) = (Color.clear, "");
             //trueRoleNameでColor上書きあればそれになる
             player.GetRoleClass()?.OverrideTrueRoleName(ref c, ref t);
             if (c != Color.clear) return ColorUtility.ToHtmlStringRGB(c);
-            else return Utils.GetRoleColorCode(player.GetCustomRole());
+            else return Utils.GetRoleColorCode(role);
         }
-        public static Color GetRoleColor(this PlayerControl player)
+        public static Color GetRoleColor(this PlayerControl player, bool temporaryRole = false)
         {
+            var role = player.GetCustomRole();
+            if (temporaryRole)
+            {
+            }
+
             (Color c, string t) = (Color.clear, "");
             //trueRoleNameでColor上書きあればそれになる
             player.GetRoleClass()?.OverrideTrueRoleName(ref c, ref t);
             if (c != Color.clear) return c;
-            else return Utils.GetRoleColor(player.GetCustomRole());
+            else return Utils.GetRoleColor(role);
         }
         public static void ResetPlayerCam(this PlayerControl pc, float delay = 0f)
         {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -374,6 +374,8 @@ namespace TownOfHostY
             var role = player.GetCustomRole();
             if (temporaryRole)
             {
+                if (player.Is(CustomRoles.ChainShifterAddon))
+                    return Utils.GetRoleColorCode(CustomRoles.ChainShifter);
             }
 
             (Color c, string t) = (Color.clear, "");
@@ -387,6 +389,8 @@ namespace TownOfHostY
             var role = player.GetCustomRole();
             if (temporaryRole)
             {
+                if (player.Is(CustomRoles.ChainShifterAddon))
+                    return Utils.GetRoleColor(CustomRoles.ChainShifter);
             }
 
             (Color c, string t) = (Color.clear, "");
@@ -623,6 +627,8 @@ namespace TownOfHostY
             var role = player.GetCustomRole();
             
             role = role.IsVanillaRoleConversion();//変換
+
+            if (player.Is(CustomRoles.ChainShifterAddon)) role = CustomRoles.ChainShifter;
 
             var Prefix = "";
             var text = role.ToString();

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -46,18 +46,12 @@ namespace TownOfHostY
             var state = PlayerState.GetByPlayerId(seer.PlayerId);
             if (!state.TargetColorData.TryGetValue(target.PlayerId, out var value)) return false;
             colorCode = value;
+            if (colorCode == "") colorCode = target.GetRoleColorCode();
             return true;
         }
 
         public static void Add(byte seerId, byte targetId, string colorCode = "")
         {
-            if (colorCode == "")
-            {
-                var target = Utils.GetPlayerById(targetId);
-                if (target == null) return;
-                colorCode = target.GetRoleColorCode();
-            }
-
             var state = PlayerState.GetByPlayerId(seerId);
             if (state.TargetColorData.TryGetValue(targetId, out var value) && colorCode == value) return;
             state.TargetColorData.Add(targetId, colorCode);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -288,6 +288,10 @@ public static class Utils
                         roleText.Append(ColorString(Utils.GetRoleColor(subRole), GetRoleString("Archenemy")));
                         count--;
                         break;
+                    case CustomRoles.ChainShifterAddon:
+                        //AddOnとしては表示しない
+                        count--;
+                        break;
                 }
             }
 
@@ -303,7 +307,7 @@ public static class Utils
                     int i = 0;
                     foreach (var subRole in subRolesList)
                     {
-                        if (subRole is CustomRoles.LastImpostor or CustomRoles.CompleteCrew or CustomRoles.Archenemy) continue;
+                        if (subRole is CustomRoles.LastImpostor or CustomRoles.CompleteCrew or CustomRoles.Archenemy or CustomRoles.ChainShifterAddon) continue;
 
                         roleText.Append(ColorString(GetRoleColor(subRole), GetRoleName(subRole)));
                         i++;
@@ -312,6 +316,11 @@ public static class Utils
                 }
             }
         }
+
+        if (subRolesList.Contains(CustomRoles.ChainShifterAddon))
+            mainRole = CustomRoles.ChainShifter;
+        else if (mainRole == CustomRoles.ChainShifter)
+            mainRole = ChainShifter.ShiftedRole;
 
         if (mainRole < CustomRoles.StartAddon)
         {
@@ -347,7 +356,7 @@ public static class Utils
         {
             foreach (var subRole in subRolesList)
             {
-                if (subRole is CustomRoles.LastImpostor or CustomRoles.CompleteCrew or CustomRoles.Archenemy) continue;
+                if (subRole is CustomRoles.LastImpostor or CustomRoles.CompleteCrew or CustomRoles.Archenemy or CustomRoles.ChainShifterAddon) continue;
                 switch (subRole)
                 {
                     case CustomRoles.AddWatch: sb.Append(AddWatch.SubRoleMark); break;
@@ -540,7 +549,8 @@ public static class Utils
                 {
                     case CustomRoles.Lovers:
                     case CustomRoles.Archenemy:
-                        //ラバーズはタスクを勝利用にカウントしない
+                    case CustomRoles.ChainShifterAddon:
+                        //タスクを勝利用にカウントしない
                         hasTasks &= !ForRecompute;
                         break;
                 }
@@ -1035,7 +1045,8 @@ public static class Utils
         foreach (var role in SubRoles)
         {
             if (role is CustomRoles.NotAssigned or
-                        CustomRoles.LastImpostor) continue;
+                        CustomRoles.LastImpostor or
+                        CustomRoles.ChainShifterAddon) continue;
 
             var RoleText = disableColor ? GetRoleName(role) : ColorString(GetRoleColor(role), GetRoleName(role));
             sb.Append($"{ColorString(Color.gray, " + ")}{RoleText}");
@@ -1387,6 +1398,7 @@ public static class Utils
         foreach (var roleClass in CustomRoleManager.AllActiveRoles.Values)
             roleClass.AfterMeetingTasks();
         Counselor.AfterMeetingTask();
+        ChainShifterAddon.AfterMeetingTasks();
         if (Options.AirShipVariableElectrical.GetBool())
             AirShipElectricalDoors.Initialize();
         DoorsReset.ResetDoors();

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1237,7 +1237,7 @@ public static class Utils
             string SelfDeathReason = seer.KnowDeathReason(seer) ? $"({ColorString(GetRoleColor(CustomRoles.Doctor), GetVitalText(seer.PlayerId))})" : "";
 
             string SelfName = "";
-            Color SelfNameColor = seer.GetRoleColor();
+            Color SelfNameColor = seer.GetRoleColor(true);
 
             //string t = "";
             //trueRoleNameでColor上書きあればそれにする // GetRoleColorでOverrideTrueRoleNameを処理しているため不要

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1239,9 +1239,9 @@ public static class Utils
             string SelfName = "";
             Color SelfNameColor = seer.GetRoleColor();
 
-            string t = "";
-            //trueRoleNameでColor上書きあればそれにする
-            seer.GetRoleClass()?.OverrideTrueRoleName(ref SelfNameColor,ref t);
+            //string t = "";
+            //trueRoleNameでColor上書きあればそれにする // GetRoleColorでOverrideTrueRoleNameを処理しているため不要
+            //seer.GetRoleClass()?.OverrideTrueRoleName(ref SelfNameColor,ref t);
             //if (Options.IsONMode && Main.DefaultRole[seer.PlayerId] != CustomRoles.ONPhantomThief)
             //    SelfNameColor = GetRoleColor(Main.DefaultRole[seer.PlayerId]);
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -648,6 +648,7 @@ public static class Utils
             myRole = CustomRoles.Crewmate;
             roleInfoLong = GetString("PotentialistInfo");
         }
+        if (player.Is(CustomRoles.ChainShifterAddon)) myRole = CustomRoles.ChainShifter;
         var roleName = myRole.ToString();
         if (myRole == CustomRoles.Bakery && Bakery.IsNeutral(player))
             roleName = "NBakery";

--- a/Patches/ChatBubblePatch.cs
+++ b/Patches/ChatBubblePatch.cs
@@ -16,7 +16,7 @@ namespace TownOfHostY.Patches
         public static void Postfix(ChatBubble __instance)
         {
             if (GameStates.IsInGame && __instance.playerInfo.PlayerId == PlayerControl.LocalPlayer.PlayerId)
-                __instance.NameText.color = PlayerControl.LocalPlayer.GetRoleColor();
+                __instance.NameText.color = PlayerControl.LocalPlayer.GetRoleColor(true);
         }
     }
 }

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -131,6 +131,16 @@ namespace TownOfHostY
                     }
                     //弁護士且つ追跡者
                     Lawyer.EndGameCheck();
+
+                    //確定敗北陣営
+                    foreach (var pc in Main.AllPlayerControls)
+                    {
+                        if (pc.Is(CustomRoles.ChainShifterAddon))
+                        {
+                            if (CustomWinnerHolder.WinnerIds.Contains(pc.PlayerId))
+                                CustomWinnerHolder.WinnerIds.Remove(pc.PlayerId);
+                        }
+                    }
                 }
                 ShipStatus.Instance.enabled = false;
                 StartEndGame(reason);

--- a/Patches/HudPatch.cs
+++ b/Patches/HudPatch.cs
@@ -185,7 +185,7 @@ namespace TownOfHostY
         public static void Postfix(Vent __instance, [HarmonyArgument(1)] ref bool mainTarget)
         {
             var player = PlayerControl.LocalPlayer;
-            Color color = PlayerControl.LocalPlayer.GetRoleColor();
+            Color color = PlayerControl.LocalPlayer.GetRoleColor(true);
             ((Renderer)__instance.myRend).material.SetColor("_OutlineColor", color);
             ((Renderer)__instance.myRend).material.SetColor("_AddColor", mainTarget ? color : Color.clear);
         }
@@ -238,7 +238,7 @@ namespace TownOfHostY
             {
                 var RoleWithInfo = $"{player.GetTrueRoleName()}:\r\n";
                 RoleWithInfo += player.GetRoleInfo();
-                __instance.taskText.text = Utils.ColorString(player.GetRoleColor(), RoleWithInfo) + "\n" + __instance.taskText.text;
+                __instance.taskText.text = Utils.ColorString(player.GetRoleColor(true), RoleWithInfo) + "\n" + __instance.taskText.text;
             }
 
             // RepairSenderの表示

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -55,6 +55,7 @@ public static class MeetingHudPatch
             GameStates.AlreadyDied |= !Utils.IsAllAlive;
             Main.AllPlayerControls.Do(x => ReportDeadBodyPatch.WaitReport[x.PlayerId].Clear());
             Sending.OnStartMeeting();
+            ChainShifterAddon.OnStartMeeting();
             foreach (var tm in Main.AllAlivePlayerControls.Where(p=>p.Is(CustomRoles.TaskManager) || p.Is(CustomRoles.Management)))
                 Utils.NotifyRoles(true, tm);
             TargetDeadArrow.OnStartMeeting();
@@ -325,6 +326,9 @@ public static class MeetingHudPatch
 
             // 第三陣営を道連れするか（設定）
             if (candidate.Is(CustomRoleTypes.Neutral) && !Options.RevengeNeutral.GetBool()) continue;
+
+            // チェインシフターは道連れされない（涙）
+            if (candidate.Is(CustomRoles.ChainShifterAddon)) continue;
 
             TargetList.Add(candidate);
         }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -139,7 +139,7 @@ public static class MeetingHudPatch
                     foreach (var seen in Main.AllPlayerControls)
                     {
                         var seenName = seen.GetRealName(isMeeting: true);
-                        var coloredName = Utils.ColorString(seen.GetRoleColor(), seenName);
+                        var coloredName = Utils.ColorString(seen.GetRoleColor(true), seenName);
                         foreach (var seer in Main.AllPlayerControls)
                         {
                             seen.RpcSetNamePrivate(

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -584,7 +584,7 @@ namespace TownOfHostY
                         if (target.Is(CustomRoles.SeeingOff) || target.Is(CustomRoles.Sending) || target.Is(CustomRoles.MadDilemma))
                             RealName = Sending.RealNameChange(RealName);
                         else if (Options.IsCCMode)
-                            RealName = Utils.ColorString(seer.GetRoleColor(), seer.GetRoleInfo());
+                            RealName = Utils.ColorString(seer.GetRoleColor(true), seer.GetRoleInfo());
                     }
 
                     //NameColorManager準拠の処理

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -341,6 +341,8 @@ DSchrodingerCat,(Dark)SCat,(Dark)シュレ猫,(潜藏)薛定谔的猫,(Dark)薛�
 "Ogre","Ogre","鬼",
 "Pirate","Pirate","海賊",
 "Gang","Gang","一味",
+"ChainShifter","ChainShifter","チェインシフター",
+"ChainShifterAddon","","",
 
 "ArsonistInfo","Burn them to crisps","燃やせ","火焰给我燃烧起来吧！","燒吧，燒吧，燃燒吧","Облейте и подожгите всех игроков","Queime tudo em pedacinhos"
 "JesterInfo","Get voted out","追放されよう","让他们把你这个假货投出去","想個辦法讓你被投出去","Заставь игроков изгнать себя","Seja exilado"
@@ -372,6 +374,8 @@ DSchrodingerCatInfo,You are now on Team Darkhide,ダークハイドの味方に�
 "OgreInfo","I held the club!","金棒を持たせたな？",
 "PirateInfo","I am the captain of the pirates","海賊団船長とはこの私だ",
 "GangInfo","As Gang, we're going to make sure the captain wins","一味として船長を勝たせるんだ",
+"ChainShifterInfo","You Have a Joker","あなたは負けよっ！",
+"ChainShifterAddonInfo","","",
 
 "ArsonistInfoLong","(Neutrals):\nWhen you use the kill button, you douse your target in oil.\nAfter dousing all living players, you set everything ablaze and win by venting.","(ニュートラル):\nキルボタンを使おうとすると、ターゲットに油を塗れる。\nすべてのクルーに油を塗ったら船を燃やして勝利する。","(独立阵营):\n纵火犯可以通过对玩家点击击杀按钮并在跟随其数秒来完成涂油行为。\n当所有存活玩家都被纵火犯涂油后，纵火犯可以通过跳通风管来点火，并单独获得胜利。","(中立):\n當縱火犯嘗試使用殺人鍵,它將對他身邊最近的一個人澆上油,\n當他對所有玩家澆上油之後,縱火縱火犯點火即勝利。","(Нейтрал):\nПоджигатель может обливать игроков, нажав на кнопку 'Убить' и находясь рядом с игроком в течение нескольких секунд. \nПосле того как он обольёт всех живых игроков Поджигатель сможет запрыгнуть в вентиляцию, чтобы поджечь всех игроков, что приводит к победе Поджигателя.","(Neutros):\nAo apertar o botão de matar, você encharca o seu inimigo em óleo.\nApós ter encharcado todos os jogadores vivos, você coloca tudo em chamas e ganha entrando na ventilação."
 "JesterInfoLong","(Neutrals):\nYou solo victory by getting voted out during a meeting.\nIf the game ends without you getting voted out, or if you are killed, you lose.","(ニュートラル):\n会議で追放された時に単独勝利できる。\n追放されず試合が終了orキルされると敗北。","(独立阵营):\n小丑被放逐则小丑单独游戏胜利。\n游戏结束时若小丑仍存活则小丑输掉游戏。","(中立):\n當小丑被丟出時即宣告小丑獲勝,\n但是小丑在遊戲結束時活下來或是在遊戲中被殺即宣告失敗","(Нейтрал):\nШут сможет выиграть игру, если за него проголосуют во время голосования и он будет изгнан.\nВ противном случае Шут проиграет.","(Neutros): \nVocê ganha sozinho ao ser exilado durante uma reunião. \nSe o jogo terminar com você não sendo votado, ou você for morto, você perde."
@@ -397,6 +401,8 @@ DSchrodingerCatInfo,You are now on Team Darkhide,ダークハイドの味方に�
 "OgreInfoLong","(Neutrals):\nAdditional victory is awarded if the impostor survives Ogre with at least one impostor remaining at the end of the game.\nIt has a kill button and can kill, but the probability of a successful kill decreases with each successful kill.\nWhen about to be killed by an impostor, it will guard the kill with a set probability. If the kill is from a non-impostor, it will guard the kill with a set probability and rebound to kill.","[ニュートラル]:\nゲーム決着時に、インポスターが1人以上残った状態で自身が生存していると追加で勝利する。\nキルボタンを持ちキルできるが、キル成功確率はキルに成功する毎に下がる。\nインポスターからキルされそうになった時、設定確率でキルガードする。インポスター以外からのキルの場合、設定確率でキルガードし、はね返してキルする。",
 "PirateInfoLong","(Neutrals):\nFirst, someone kills.The killed Crew member dies, but becomes a member of the pirate Gang and the victory condition changes to Pirate Victory.\nThe gang has a task, and the pirate's ability is expanded according to the gang's completion of the task.\nIf the Impostor is wiped out and the number of pirates equals or exceeds the number of crew members, wins alone.\n[Pirate ability by Gang task]\n25%：Can Vent\n50%：Can Kill\n75%：Grant Buff-Add-On\n100%：Know Impostor","[ニュートラル]\nはじめに誰かキルする。そのキルされた人は死亡するが、海賊の一味となり勝利条件が「海賊の勝利」に変化する。\n一味はタスクを持ち、一味のタスク完了度により海賊の能力が拡大する。\nインポスターの全滅かつ、海賊の数がクルーと同数または上回ると単独で勝利する。\n[一味のタスクによる海賊の能力]\n25%完了：ベント使用可能\n50%完了：キル可能\n75%完了：バフ属性の付与\n100%完了：インポスターが誰か分かる",
 "GangInfoLong","(Neutrals):\nLet's aim for a pirate victory. The gang has a task, and the pirate's ability is expanded according to the gang's completion of the task.\n[task]\n25%：Can Vent\n50%：Can Kill\n75%：Grant Buff-Add-On\n100%：Know Impostor","[ニュートラル]\n海賊の勝利を目指そう。一味のタスク完了度により海賊の能力が拡大する。\n[タスク]\n25%完了：ベント使用可能\n50%完了：キル可能\n75%完了：バフ属性の付与\n100%完了：インポスターが誰か分かる",
+"ChainShifterInfoLong","(Neutrals):\nYou lose if you end the game with ChainShifter.\nChainShifter can be transferred to another opponent by being nearby for a while.\nYou can win with the changed role after transferring the ChainShifter.","[ニュートラル]\nチェインシフターでゲームを終了すると負けになる役職。\nチェインシフターは他のクルーの近くにしばらくいることで相手に移すことができる。\nチェインシフターを移した後に変化した役職で勝利できる。","","","",""
+"ChainShifterAddonInfoLong","","",
 
 
 # Unit-Role
@@ -979,6 +985,11 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "PirateMadmateCanBeGang","Madmate Can Be Gang","マッドメイトが一味になれる",
 "PirateNeutralCanBeGang","Neutral Can Be Gang","ニュートラルが一味になれる",
 "PirateBuffAddonAssignTarget","Buff Add-On To Be Granted (Gang Task 75%)","一味のタスク75%で付与するバフ属性",
+"ChainShifterShiftTime","Shift Time","シフトする時間",
+"ChainShifterShiftDistance","Shift Distance","シフトする距離",
+"ChainShifterShiftInactiveTime","Shift Inactive Time","シフト無効時間",
+"ChainShifterShiftedRole","Role Changes Shifted","シフト後に変化する役職",
+"ChainShifterShiftWhenKilled","Shift By Killed","キルで強制シフトする",
 "Random","Random","ランダム","随机",
 
 # Unit

--- a/Roles/AddOns/Neutral/ChainShifterAddon.cs
+++ b/Roles/AddOns/Neutral/ChainShifterAddon.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Neutral;
+
+namespace TownOfHostY.Roles.AddOns.Common;
+public static class ChainShifterAddon
+{
+    //private static readonly int Id = (int)offsetId.AddonNeu + 100;
+    //public static Color RoleColor = Utils.GetRoleColor(CustomRoles.ChainShifter);
+
+    private static Dictionary<byte, float> ShiftInfo = new();
+
+    private static byte prePlayerId = byte.MaxValue;
+    private static PlayerControl Player = null;
+    private static PlayerControl nextPlayer = null;
+    private static PlayerControl nextPlayerByKill = null;
+
+    private static float postMeetingTime = 0f;
+    private static bool shiftActive = false;
+
+    public static void Init()
+    {
+        ShiftInfo = new();
+
+        prePlayerId = byte.MaxValue;
+        Player = null;
+        nextPlayer = null;
+        nextPlayerByKill = null;
+
+        postMeetingTime = 0f;
+        shiftActive = false;
+
+        //他視点用のメソッド登録
+        CustomRoleManager.OnFixedUpdateOthers.Add(OnFixedUpdateOthers);
+        CustomRoleManager.OnMurderPlayerOthers.Add(OnMurderPlayerOthers);
+    }
+    public static void Add(byte playerId)
+    {
+        Logger.Info($"Add playerId: {playerId}", "ChainShifter.Add");
+
+        Player = Utils.GetPlayerById(playerId);
+    }
+    private static void OnMurderPlayerOthers(MurderInfo info)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        if (info.IsMeeting) return;
+
+        if (Player == null) return;
+
+        if (info.AttemptTarget?.PlayerId == Player?.PlayerId)
+        {
+            SetShiftTarget(info.AttemptKiller, true);
+        }
+    }
+    public static void OnFixedUpdateOthers(PlayerControl player)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        if (!GameStates.IsInTask)
+        {
+            ShiftInfo.Clear();
+            return;
+        }
+
+        if (player == null) return;
+        if (Player == null || player.PlayerId != Player.PlayerId) return;
+        if (!player.IsAlive()) return;
+
+        if (!shiftActive) return; //初日は近接シフト禁止
+        if (nextPlayer != null) return;
+        if (postMeetingTime < ChainShifter.ShiftInactiveTime)
+        {
+            postMeetingTime += Time.deltaTime;
+            if (postMeetingTime < ChainShifter.ShiftInactiveTime) return;
+        }
+
+        foreach (var target in Main.AllAlivePlayerControls)
+        {
+            if (target.PlayerId == Player.PlayerId) continue;
+
+            if (ShiftInfo.TryGetValue(target.PlayerId, out var time))
+            {
+                ShiftInfo.Remove(target.PlayerId);
+            }
+            else 
+            {
+                time = 0f;
+            }
+
+            if (target.PlayerId == prePlayerId) continue;   //前チェインシフターは除外
+            if (target.inVent) continue;    //ベント内であれば除外
+
+            var distance = Vector3.Distance(player.transform.position, target.transform.position);
+            if (distance > ChainShifter.ShiftDistance)
+            {
+                //if (time > 0f) Logger.Info($"Chain targetOut time: {time:F2}, distance: {distance:F2}, {Player.name} => {target.name}", "ChainShifterAdd.OnFixedUpdateOthers");
+                continue;
+            }
+            //if (time == 0f) Logger.Info($"Chain targetIn distance: {distance:F2}, {Player.name} => {target.name}", "ChainShifterAdd.OnFixedUpdateOthers");
+
+            time += Time.fixedDeltaTime;
+            if (time >= ChainShifter.ShiftTime)
+            {
+                SetShiftTarget(target);
+                return;
+            }
+            ShiftInfo[target.PlayerId] = time;
+        }
+    }
+    private static void SetShiftTarget(PlayerControl target, bool byKill = false)
+    {
+        if (Player == null) return;
+
+        if (byKill)
+        {
+            nextPlayerByKill = target;
+        }
+        else
+        {
+            nextPlayer = target;
+            ShiftInfo.Clear();
+        }
+
+        Logger.Info($"setChainTarget {Player?.name} => {nextPlayer?.name}, bykill: {byKill}", "ChainShifterAdd.SetShiftTarget");
+
+        if (Player.CanUseKillButton())
+        {
+            Player.SetKillCooldown();
+            Logger.Info($"SetKillCooldown", "ChainShifterAdd.SetShiftTarget");
+        }
+        else
+        {
+            Player.RpcProtectedMurderPlayer();
+            Logger.Info($"RpcProtectedMurderPlayer", "ChainShifterAdd.SetShiftTarget");
+        }
+    }
+    public static void OnStartMeeting()
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        shiftActive = false;
+        postMeetingTime = 0f;
+    }
+    public static void AfterMeetingTasks()
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        shiftActive = true;
+        postMeetingTime = 0f;
+        ChainShift();
+    }
+    private static void ChainShift()
+    {
+        postMeetingTime = 0f;
+        ShiftInfo.Clear();
+
+        if (Player == null) return;
+        if (nextPlayer == null && nextPlayerByKill == null) return;
+
+        var nowPlayer = Player;
+        var next = nextPlayerByKill;
+        if (nextPlayer != null && (next == null || !next.IsAlive())) next = nextPlayer;
+
+        Logger.Info($"target player: {nowPlayer?.name}, next: {nextPlayer?.name}(alive: {nextPlayer?.IsAlive()}), nextByKill: {nextPlayerByKill?.name}(alive: {nextPlayerByKill?.IsAlive()})", "ChainShifterAdd.ChainShift");
+        Logger.Info($"targetFix target: {next?.name}", "ChainShifterAdd.ChainShift");
+
+        nextPlayerByKill = null;
+        nextPlayer = null;
+
+        if (!next.IsAlive())
+        {
+            Logger.Info($"ChainFail {nowPlayer.name} => {next?.name}", "ChainShifterAdd.ChainShift");
+            return;
+        }
+
+        //シフト確定
+        PlayerState.GetByPlayerId(nowPlayer.PlayerId).RemoveSubRole(CustomRoles.ChainShifterAddon);
+        next.RpcSetCustomRole(CustomRoles.ChainShifterAddon);
+        Logger.Info($"shift {nowPlayer.name} => {next?.name}", "ChainShifterAdd.ChainShift");
+
+        if (nowPlayer.Is(CustomRoles.ChainShifter))
+        {
+            nowPlayer.RpcSetCustomRole(ChainShifter.ShiftedRole);
+            Logger.Info($"roleChange {nowPlayer.name} => {ChainShifter.ShiftedRole}", "ChainShifterAdd.ChainShift");
+        }
+
+        prePlayerId = nowPlayer.PlayerId;
+        nowPlayer = next;
+        Logger.Info($"preShifter player: {prePlayerId}", "ChainShifterAdd.ChainShift");
+
+        nowPlayer.SyncSettings();
+        Utils.NotifyRoles();
+    }
+}

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 
 using static TownOfHostY.Translator;
 using HarmonyLib;
+using TownOfHostY.Roles.Neutral;
+
 namespace TownOfHostY.Roles.Core.Class;
 
 public abstract class VoteGuesser : RoleBase
@@ -314,10 +316,17 @@ public abstract class VoteGuesser : RoleBase
         private void SetRoleList()
         {
             roleList = new();
+            var inChainShifter = false;
             foreach (CustomRoles role in CustomRolesHelper.AllStandardRoles.Where(r => r.IsEnable()))
             {
                 if (role is CustomRoles.LastImpostor or CustomRoles.Lovers or CustomRoles.Workhorse) continue;
                 roleList.Add(role);
+                if (role == CustomRoles.ChainShifter) inChainShifter = true;
+            }
+            if (inChainShifter)
+            {
+                var role = ChainShifter.ShiftedRole;
+                if (!roleList.Contains(role)) roleList.Add(role);
             }
         }
         private void SetDispList()

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -262,6 +262,7 @@ public static class CustomRoleManager
         switch (subRole)
         {
             case CustomRoles.Lovers: Lovers.Add(playerId); break;
+            case CustomRoles.ChainShifterAddon: ChainShifterAddon.Add(playerId); break;
 
             case CustomRoles.AddWatch: AddWatch.Add(playerId); break;
             case CustomRoles.AddLight: AddLight.Add(playerId); break;
@@ -546,6 +547,7 @@ public enum CustomRoles
     Ogre,
     Pirate,
     Gang,
+    ChainShifter,
 
     GM,
     CounselorAndMadDilemma,
@@ -604,6 +606,7 @@ public enum CustomRoles
     InfoPoor,
     NonReport,
     Archenemy,
+    ChainShifterAddon,
 
     MaxAddon,
 

--- a/Roles/Neutral/Y/ChainShifter.cs
+++ b/Roles/Neutral/Y/ChainShifter.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.AddOns.Common;
+
+namespace TownOfHostY.Roles.Neutral;
+
+public sealed class ChainShifter : RoleBase
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+        SimpleRoleInfo.Create(
+            typeof(ChainShifter),
+            player => new ChainShifter(player),
+            CustomRoles.ChainShifter,
+            () => RoleTypes.Crewmate,
+            CustomRoleTypes.Neutral,
+            (int)Options.offsetId.NeuY + 1100,
+            SetupOptionItem,
+            "チェインシフター",
+            "#666666",
+            assignInfo: new RoleAssignInfo(CustomRoles.ChainShifter, CustomRoleTypes.Neutral)
+            {
+                AssignCountRule = new(1, 1, 1)
+            }
+        );
+    public ChainShifter(PlayerControl player)
+    : base(
+        RoleInfo,
+        player,
+        () => HasTask.ForRecompute
+    )
+    {
+        ShiftTime = OptionShiftTime.GetFloat();
+        ShiftDistance = OptionShiftDistance.GetFloat();
+        ShiftInactiveTime = OptionShiftInactiveTime.GetFloat();
+        ShiftedRole = ChangeRoles[OptionShiftedRole.GetValue()];
+        ShiftWhenKilled = OptionShiftWhenKilled.GetBool();
+
+        ChainShifterAddon.Init();
+    }
+
+    private static OptionItem OptionShiftTime;
+    private static OptionItem OptionShiftDistance;
+    private static OptionItem OptionShiftInactiveTime;
+    private static OptionItem OptionShiftedRole;
+    private static OptionItem OptionShiftWhenKilled;
+
+    public static float ShiftTime;
+    public static float ShiftDistance;
+    public static float ShiftInactiveTime;
+    public static CustomRoles ShiftedRole = CustomRoles.Opportunist;
+    public static bool ShiftWhenKilled;
+    enum OptionName
+    {
+        ChainShifterShiftTime,
+        ChainShifterShiftDistance,
+        ChainShifterShiftInactiveTime,
+        ChainShifterShiftedRole,
+        ChainShifterShiftWhenKilled,
+    }
+    public static readonly CustomRoles[] ChangeRoles =
+    {
+            CustomRoles.Opportunist, CustomRoles.Jester, CustomRoles.Crewmate, CustomRoles.God,
+    };
+    private static void SetupOptionItem()
+    {
+        var cRolesString = ChangeRoles.Select(x => x.ToString()).ToArray();
+        OptionShiftTime = FloatOptionItem.Create(RoleInfo, 10, OptionName.ChainShifterShiftTime, new(1f, 10f, 1f), 4f, false)
+           .SetValueFormat(OptionFormat.Seconds);
+        OptionShiftDistance = FloatOptionItem.Create(RoleInfo, 11, OptionName.ChainShifterShiftDistance, new(0.5f, 2f, 0.1f), 1f, false);
+        OptionShiftInactiveTime = FloatOptionItem.Create(RoleInfo, 12, OptionName.ChainShifterShiftInactiveTime, new(10f, 60f, 2.5f), 10f, false)
+           .SetValueFormat(OptionFormat.Seconds);
+        OptionShiftedRole = StringOptionItem.Create(RoleInfo, 13, OptionName.ChainShifterShiftedRole, cRolesString, 1, false);
+        OptionShiftWhenKilled = BooleanOptionItem.Create(RoleInfo, 14, OptionName.ChainShifterShiftWhenKilled, false, false);
+    }
+    public override void Add()
+    {
+        Player.RpcSetCustomRole(CustomRoles.ChainShifterAddon);
+    }
+}


### PR DESCRIPTION
チェインシフター（第三陣営）
　チェインシフターのままゲームを終了すると負けになる役職。
　他のクルーの近くにしばらくいることで、役職「チェインシフター」を相手に移すことができる。
　チェインシフターを移した後に変化した役職で勝利できる。
　役職の移動は、タスクゲーム中に対象を決定、会議の後に移される。

設定
　シフトする時間：役職のシフトにかかる時間（設定時間中常に近接が必要）
　シフトする距離：役職シフトのための近接の距離
　シフト無効時間：各会議後の役職シフトができるようになるクールダウン時間
　シフト後に変化する役職：チェインシフターを他の人に移したときになる役職
　キルで強制シフトする：キルされたときにキルした人を強制的に役職シフトの対象とする

チェインシフターの詳細仕様
　役職は会議終了後（吊り判定より後）にシフトされます。
　ゲーム開始直後、最初の会議まではシフト指定が発生しません。（キル強制は除く）
　シフト対象を指定できるとシールドが発生して指定できたことがわかります。
　チェインシフターを移された相手を次のシフト対象に指定することはできません。
　ベント内の人をシフト対象にすることはできません。
　会議終了後に移す対象がいない（死んでいる）とシフトは発生しません。
　会議終了時にチェインシフター自身が死んでいてもシフトは発生します。
　チェインシフターのまま死亡した場合はそれ以降シフトすることはできません。
　キルでのシフトが有効な場合、キルした人＞近接での対象者 の優先順でシフトが発生します。
　会議後にゲームが終了する場合、会議後シフトが発生した後にゲームが終了します。
　キル可能なクルーがシフト対象を指定した場合、キルクールダウンはリセットされます。
　チェインシフターになった場合でも元の役職の能力は使用できます。