### PR TITLE
feature）ゲッサーが投票後に能力を使用できるようにする

### DIFF
--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -741,6 +741,7 @@ GhostCanSeeOtherTasks,"Ghosts Can't See Other Tasks","幽霊が他人のタス�
 "GuesserNumOfGuess","Number Of Guess","推測の回数","","","",""
 "GuesserMultipleInMeeting","Multiple In Meeting","一会議での複数使用","","","",""
 "GuesserHideMisfire","Hide DeathReason Misfire","死因 誤爆を隠す","","","",""
+"GuesserGuessAfterVote","Guess After Voted","投票後の能力使用","","","",""
 
 # インポスター
 "BountyTargetChangeTime","Time Until Target Swaps","ターゲット変更時間","赏金目标切换时间","賞金目標切換時間","Время смены цели","Tempo Para Troca de Alvos"

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -28,6 +28,7 @@ public abstract class VoteGuesser : RoleBase
         guesserInfo = null;
 
         selecting = false;
+        voted = false;
         guessed = false;
         targetGuess = null;
         targetForRole = null;
@@ -36,11 +37,13 @@ public abstract class VoteGuesser : RoleBase
     protected int NumOfGuess = 1;
     protected bool MultipleInMeeting = false;
     protected bool HideMisfire = false;
+    protected bool GuessAfterVote = false;
 
     private GuesserInfo guesserInfo;
 
     private bool selecting = false;
     private bool guessed = false;
+    private bool voted = false;
     private PlayerControl targetGuess = null;
     private PlayerControl targetForRole = null;
 
@@ -93,7 +96,7 @@ public abstract class VoteGuesser : RoleBase
                     targetGuess = null;
                     targetForRole = null;
                     Utils.SendMessage(GetString("Message.GuesserSelectionSelfSelect"), Player.PlayerId);
-                    return true;
+                    return DoVote();
                 }
                 targetGuess = votedFor;
                 guesserInfo.ResetList();
@@ -156,7 +159,7 @@ public abstract class VoteGuesser : RoleBase
 
             return false;
         }
-        if (votedFor == null) return true;
+        if (votedFor == null) return DoVote();
         if (Player.PlayerId == votedFor.PlayerId && NumOfGuess > 0)
         {
             Logger.Info($"GuesserSelectStart guesser: {Player?.name}", "Guesser.CheckVoteAsVoter");
@@ -168,7 +171,17 @@ public abstract class VoteGuesser : RoleBase
             return false;
         }
 
-        return true;
+        return DoVote();
+    }
+    private bool DoVote()
+    {
+        if (!GuessAfterVote) return true;
+
+        var vote = !voted;
+        voted = true;
+        _ = new LateTask(() => MeetingHud.Instance.RpcClearVote(Player.GetClientId()), 0.5f, "GuesserClearVote");
+
+        return vote;
     }
     private void UseGuesserAbility(CustomRoles role)
     {
@@ -229,6 +242,7 @@ public abstract class VoteGuesser : RoleBase
     {
         selecting = false;
         guessed = false;
+        voted = false;
         targetGuess = null;
         targetForRole = null;
 

--- a/Roles/Crewmate/Y/NiceGuesser.cs
+++ b/Roles/Crewmate/Y/NiceGuesser.cs
@@ -28,15 +28,18 @@ public sealed class NiceGuesser : VoteGuesser
         NumOfGuess = OptionNumOfGuess.GetInt();
         MultipleInMeeting = OptionMultipleInMeeting.GetBool();
         HideMisfire = OptionHideMisfire.GetBool();
+        GuessAfterVote = OptionGuessAfterVote.GetBool();
     }
     private static OptionItem OptionNumOfGuess;
     private static OptionItem OptionMultipleInMeeting;
     private static OptionItem OptionHideMisfire;
+    private static OptionItem OptionGuessAfterVote;
     enum OptionName
     {
         GuesserNumOfGuess,
         GuesserMultipleInMeeting,
         GuesserHideMisfire,
+        GuesserGuessAfterVote,
     }
     public static void SetupOptionItem()
     {
@@ -44,5 +47,6 @@ public sealed class NiceGuesser : VoteGuesser
             .SetValueFormat(OptionFormat.Times);
         OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 11, OptionName.GuesserMultipleInMeeting, false, false);
         OptionHideMisfire = BooleanOptionItem.Create(RoleInfo, 12, OptionName.GuesserHideMisfire, false, false);
+        OptionGuessAfterVote = BooleanOptionItem.Create(RoleInfo, 13, OptionName.GuesserGuessAfterVote, false, false);
     }
 }

--- a/Roles/Impostor/Y/EvilGuesser.cs
+++ b/Roles/Impostor/Y/EvilGuesser.cs
@@ -27,15 +27,18 @@ public sealed class EvilGuesser : VoteGuesser, IImpostor
         NumOfGuess = OptionNumOfGuess.GetInt();
         MultipleInMeeting = OptionMultipleInMeeting.GetBool();
         HideMisfire = OptionHideMisfire.GetBool();
+        GuessAfterVote = OptionGuessAfterVote.GetBool();
     }
     private static OptionItem OptionNumOfGuess;
     private static OptionItem OptionMultipleInMeeting;
     private static OptionItem OptionHideMisfire;
+    private static OptionItem OptionGuessAfterVote;
     enum OptionName
     {
         GuesserNumOfGuess,
         GuesserMultipleInMeeting,
         GuesserHideMisfire,
+        GuesserGuessAfterVote,
     }
     public static void SetupOptionItem()
     {
@@ -43,5 +46,6 @@ public sealed class EvilGuesser : VoteGuesser, IImpostor
             .SetValueFormat(OptionFormat.Times);
         OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 11, OptionName.GuesserMultipleInMeeting, false, false);
         OptionHideMisfire = BooleanOptionItem.Create(RoleInfo, 12, OptionName.GuesserHideMisfire, false, false);
+        OptionGuessAfterVote = BooleanOptionItem.Create(RoleInfo, 13, OptionName.GuesserGuessAfterVote, false, false);
     }
 }

--- a/Roles/Madmate/Y/MadGuesser.cs
+++ b/Roles/Madmate/Y/MadGuesser.cs
@@ -39,6 +39,7 @@ public sealed class MadGuesser : VoteGuesser, IKillFlashSeeable, IDeathReasonSee
         NumOfGuess = OptionNumOfGuess.GetInt();
         MultipleInMeeting = OptionMultipleInMeeting.GetBool();
         HideMisfire = OptionHideMisfire.GetBool();
+        GuessAfterVote = OptionGuessAfterVote.GetBool();
 
         //CustomRoleManager.MarkOthers.Add(GetMarkOthers);
     }
@@ -48,6 +49,7 @@ public sealed class MadGuesser : VoteGuesser, IKillFlashSeeable, IDeathReasonSee
     private static OptionItem OptionNumOfGuess;
     private static OptionItem OptionMultipleInMeeting;
     private static OptionItem OptionHideMisfire;
+    private static OptionItem OptionGuessAfterVote;
     /// <summary>能力発動タスク数</summary>
     //private static OptionItem OptionTaskTrigger;
     //private static Options.OverrideTasksData Tasks;
@@ -59,6 +61,7 @@ public sealed class MadGuesser : VoteGuesser, IKillFlashSeeable, IDeathReasonSee
         GuesserNumOfGuess,
         GuesserMultipleInMeeting,
         GuesserHideMisfire,
+        GuesserGuessAfterVote,
     }
     //private static bool CanSeeKillFlash;
     //private static bool CanSeeDeathReason;
@@ -74,6 +77,7 @@ public sealed class MadGuesser : VoteGuesser, IKillFlashSeeable, IDeathReasonSee
             .SetValueFormat(OptionFormat.Times);
         OptionMultipleInMeeting = BooleanOptionItem.Create(RoleInfo, 14, OptionName.GuesserMultipleInMeeting, false, false);
         OptionHideMisfire = BooleanOptionItem.Create(RoleInfo, 15, OptionName.GuesserHideMisfire, false, false);
+        OptionGuessAfterVote = BooleanOptionItem.Create(RoleInfo, 17, OptionName.GuesserGuessAfterVote, false, false);
         //OptionTaskTrigger = IntegerOptionItem.Create(RoleInfo, 12, OptionName.MadSnitchTaskTrigger, new(0, 99, 1), 1, false).SetValueFormat(OptionFormat.Pieces);
         //Tasks = Options.OverrideTasksData.Create(RoleInfo, 20);
         Options.SetUpAddOnOptions(RoleInfo.ConfigId + 30, RoleInfo.RoleName, RoleInfo.Tab);


### PR DESCRIPTION
設定によりゲッサーが投票後に能力を使用できるようにする
対象はナイスゲッサー、イビルゲッサー、マッドゲッサーの３種

設定
　投票後の能力使用

設定がONの場合、ゲッサーは通常投票した後も投票操作ができるようになる
実際の投票は最初の投票確定分が有効となる
例）
　スキップに投票
　自投票よりゲッサー操作
　Aに投票
　⇒ゲッサー操作は有効、投票はスキップが有効