### PR TITLE
bugFix）利用者から報告されている不具合の対応

### DIFF
--- a/Helpers/CustomRolesHelper.cs
+++ b/Helpers/CustomRolesHelper.cs
@@ -98,7 +98,8 @@ namespace TownOfHostY
             return role is CustomRoles.Counselor or CustomRoles.MadDilemma
                 or CustomRoles.Godfather or CustomRoles.Janitor
                 or CustomRoles.Gang
-                
+                or CustomRoles.SKMadmate
+
                 or CustomRoles.Potentialist
                 or CustomRoles.Impostor or CustomRoles.Crewmate;
         }

--- a/Modules/CustomWinnerHolder.cs
+++ b/Modules/CustomWinnerHolder.cs
@@ -21,6 +21,9 @@ namespace TownOfHostY
         // 勝者のPlayerIDが格納され、このIDを持つプレイヤーは全員勝利します。
         // 単独勝利するニュートラルの処理に最適です。
         public static HashSet<byte> WinnerIds;
+        // 敗者のPlayerIDが格納され、このIDを持つプレイヤーは全員敗北します。
+        // 敗者リストは勝者リスト、勝者チームのリストより優先されます。
+        public static HashSet<byte> LoserIds;
 
         [GameModuleInitializer, PluginModuleInitializer]
         public static void Reset()
@@ -29,11 +32,13 @@ namespace TownOfHostY
             AdditionalWinnerRoles = new();
             WinnerRoles = new();
             WinnerIds = new();
+            LoserIds = new();
         }
         public static void ClearWinners()
         {
             WinnerRoles.Clear();
             WinnerIds.Clear();
+            LoserIds.Clear();
         }
         /// <summary><para>WinnerTeamに値を代入します。</para><para>すでに代入されている場合、AdditionalWinnerRolesに追加します。</para></summary>
         public static void SetWinnerOrAdditonalWinner(CustomWinner winner)
@@ -71,6 +76,10 @@ namespace TownOfHostY
             foreach (var id in WinnerIds)
                 writer.Write(id);
 
+            writer.WritePacked(LoserIds.Count);
+            foreach (var id in LoserIds)
+                writer.Write(id);
+
             return writer;
         }
         public static void ReadFrom(MessageReader reader)
@@ -91,6 +100,11 @@ namespace TownOfHostY
             int WinnerIdsCount = reader.ReadPackedInt32();
             for (int i = 0; i < WinnerIdsCount; i++)
                 WinnerIds.Add(reader.ReadByte());
-        }
+
+            LoserIds = new();
+            int LoserIdsCount = reader.ReadPackedInt32();
+            for (int i = 0; i < LoserIdsCount; i++)
+                LoserIds.Add(reader.ReadByte());
+       }
     }
 }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1260,8 +1260,8 @@ public static class Utils
 
         var caller = new System.Diagnostics.StackFrame(1, false);
         var callerMethod = caller.GetMethod();
-        string callerMethodName = callerMethod.Name;
-        string callerClassName = callerMethod.DeclaringType.FullName;
+        string callerMethodName = callerMethod?.Name;
+        string callerClassName = callerMethod?.DeclaringType?.FullName;
         var logger = Logger.Handler("NotifyRoles");
         logger.Info("NotifyRolesが" + callerClassName + "." + callerMethodName + "から呼び出されました");
         HudManagerPatch.NowCallNotifyRolesCount++;

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -140,6 +140,8 @@ namespace TownOfHostY
                         {
                             if (CustomWinnerHolder.WinnerIds.Contains(pc.PlayerId))
                                 CustomWinnerHolder.WinnerIds.Remove(pc.PlayerId);
+                            if (!CustomWinnerHolder.LoserIds.Contains(pc.PlayerId))
+                                CustomWinnerHolder.LoserIds.Add(pc.PlayerId);
                         }
                     }
                 }

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -37,6 +37,7 @@ namespace TownOfHostY
             //ゲーム終了時
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
             {
+                Logger.Info($"GameEnd winner: {CustomWinnerHolder.WinnerTeam}, reason: {reason}", "GameEndChecker");
                 //カモフラージュ強制解除
                 Main.AllPlayerControls.Do(pc => Camouflage.RpcSetSkin(false, pc, ForceRevert: true, RevertToDefault: true));
 
@@ -374,6 +375,7 @@ namespace TownOfHostY
             {
                 reason = GameOverReason.HumansByTask;
                 CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Crewmate);
+                Logger.Info($"GemeEndByTask task: {GameData.Instance.CompletedTasks}/{GameData.Instance.TotalTasks}", "CheckGameEndByTask");
                 return true;
             }
             return false;

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -57,6 +57,10 @@ namespace TownOfHostY
             {
                 winner.AddRange(Main.AllPlayerControls.Where(p => p.Is(team) && !winner.Contains(p)));
             }
+            foreach (var pc in Main.AllPlayerControls)
+            {
+                winner.RemoveAll(x => x.PlayerId == pc.PlayerId);
+            }
 
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Draw && CustomWinnerHolder.WinnerTeam != CustomWinner.None)
             {

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -50,7 +50,6 @@ public abstract class RoleBase : IDisposable
             RoleTypes.Engineer or
             RoleTypes.Scientist or
             RoleTypes.Tracker or
-            RoleTypes.Noisemaker or
             RoleTypes.GuardianAngel or
             RoleTypes.CrewmateGhost or
             RoleTypes.ImpostorGhost;


### PR DESCRIPTION
報告されている不具合の対応

不具合対応
・GetMyRoleInfoでSKMadmateがエラーにならないようにする
・確定負け判定を勝ち陣営判定より優先させる
　（ジャッカル勝利がチェインシフター負けを上書きしてしまう問題の対応）
・NotifyRolesが呼び出し元によってエラーになるのを解消する
・ホストがノイズメーカーの場合に不要なボタンが出ないようにする