### PR TITLE
Feature/EvilHacker

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -25,7 +25,7 @@ namespace TownOfHostY
             if (player.GetCustomRole() == role) return;
 
             // 役職の変更・属性の追加タイミングの次回会議に説明が表示される
-            if(!Main.ShowRoleInfoAtMeeting.Contains(player.PlayerId))
+            if (!Main.ShowRoleInfoAtMeeting.Contains(player.PlayerId))
                 Main.ShowRoleInfoAtMeeting.Add(player.PlayerId);
 
             if (role < CustomRoles.StartAddon)
@@ -577,7 +577,7 @@ namespace TownOfHostY
         public static bool IsNeutralKiller(this PlayerControl player)
         {
             if (player.Is(CustomRoles.Opportunist) && Opportunist.CanKill) return true;
-            return 
+            return
                 player.GetCustomRole() is
                 CustomRoles.Egoist or
                 CustomRoles.Jackal or
@@ -622,13 +622,13 @@ namespace TownOfHostY
         {
             var roleClass = player.GetRoleClass();
             var role = player.GetCustomRole();
-            
+
             role = role.IsVanillaRoleConversion();//変換
 
             var Prefix = "";
             var text = role.ToString();
             var Info = "";
-            switch(role)
+            switch (role)
             {
                 case CustomRoles.Crewmate:
                 case CustomRoles.Impostor:
@@ -692,6 +692,19 @@ namespace TownOfHostY
         public static void RpcSnapTo(this PlayerControl pc, Vector2 position)
         {
             pc.NetTransform.RpcSnapTo(position);
+        }
+        public static void SnapToTeleport(this PlayerControl pc, Vector2 position)
+        {
+            var netTransform = pc.NetTransform;
+            if (AmongUsClient.Instance.AmClient)
+            {
+                netTransform.SnapTo(position, (ushort)(netTransform.lastSequenceId + 128));
+            }
+            ushort newSid = (ushort)(netTransform.lastSequenceId + 2);
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, SendOption.Reliable);
+            NetHelpers.WriteVector2(position, messageWriter);
+            messageWriter.Write(newSid);
+            AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
         }
         public static void RpcSnapToDesync(this PlayerControl pc, PlayerControl target, Vector2 position)
         {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -45,6 +45,7 @@ namespace TownOfHostY
         SetEvilDiviner,
         SetLawyerTarget,
         SetRemoveLawyerTarget,
+        EvilHackerWarpSync,
     }
     public enum Sounds
     {

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -62,6 +62,7 @@
 "Charger","Charger","チャージャー",
 "Chaser","Chaser","チェイサー","","","",""
 "CharismaStar","Charisma Star","カリスマスター",
+"EvilHacker","EvilHacker","イビルハッカー",
 
 "CustomImpostorInfo","I can now use abilities like that","あんな能力も使えるようになりました",
 "EvilWatcherInfo","Gaze upon all votes","みんなの投票に目を光らせよう","你可以看见所有人的投票，注意他们的选择","注意所有人的投票","Вы видите цвета голосов","Veja todos os votos"
@@ -105,6 +106,7 @@
 "ChargerInfo","Release the power all at once.","力を一気に解放する、、今だ！",
 "ChaserInfo","I will chase you to the ends of the earth.","地の果てまで追いかける…","","","",""
 "CharismaStarInfo","AAre you coming to my place？","オレんとこ来ないか？",
+"EvilHackerInfo","Hack Systmes and kill the crewmate","アドミンを駆使しクルーをキルせよ",
 
 "CustomImpostorInfoLong","(Impostors):\nImpostor with the ability to Add-On to attributes set by the host.","[インポスター陣営]\nホストによって設定された属性の能力をもつインポスター。",
 "EvilWatcherInfoLong","(Impostors):\nYou can see everyone's votes even if anonymous voting is on.","(インポスター陣営):\n全員の投票先を見ることができる。","(内鬼阵营):\n会议时窥视者可以看到所有人的投票。","(狼人陣營):\n會議時觀察者可以看到所有人的投票。","(Предатель):\nNice Watcher может видеть все цвета голосов несмотря на анонимное голосование.","(Impostores):\nVocê consegue ver os votos de todos, mesmo que os votos anônimos estejam ligados."
@@ -145,6 +147,7 @@
 "ChargerInfoLong","(Impostors):\nUse the kill button to charge the number of kills,Use the Vanish button to kill.\nNormal kills and Vanish are not possible. The second and subsequent targets on the same turn can be selected with no cooldown.\nThe charge increases the number of kills possible by one when one gauge is fully accumulated.","[インポスター陣営]\nキルボタンを使ってキル回数をチャージ、消えるボタンで溜まったキル回数を使ってキルをする。\n通常キル・透明化不可。同ターン2人目以降はクールダウン無しでキルできる。\nチャージは１ゲージ溜まり切るとキル可能回数が１増加する。"
 "ChaserInfoLong","(Impostors):\nA role that allows you to warp by transforming.\nDetects a nearby vent with a transformed target and warps there.\nYou can also return to the original position in the settings.\nIt would be funny if there were other players in front of you.\n","[インポスター陣営]\n近くに移動したいターゲットをシェイプボタンで選択すると、そのターゲットから一番近いベントにワープすることができる。ワープ時、他視点からチェイサーはそのベントから出てきたように見える(ベント開閉あり)。\n元の位置に戻る設定がONの時、設定時間後に元居た場所の近くのベントに戻る。"
 "CharismaStarInfoLong","(Impostors):\nImpostor that allows any player to assemble to the nearest vent from himself.\nThe kill button uses double clicks. The single-click kill button allows the user to select a member, while the double-click kill button is used for normal kills. Multiple members can be set up, and by pressing the disappear button, the members can be gathered into a vent near you.\nWhen the setting that allows everyone to assemble is turned on, if no one has decided on a member, everyone can assemble.\nWhen a gathering is called, if the target player is using a ladder or lift, the gathering cannot take place. If a player cannot assemble, he or she will self-suiside.","[インポスター陣営]\nプレイヤーを自身から近いベントへ集合させることができるインポスター。\nキルボタンはダブルクリックを使い分ける。シングルクリックでは集合メンバーを決め、ダブルクリックでは通常キルをする。集合メンバーは複数人設定することができ、消えるボタンを押すことでそのメンバーを自身付近のベントに集めることができる。\n全員集合できる設定をONにしている時、誰もメンバーを決めていないと全員を集合させることができる。\n集合をかけた時、対象プレイヤーがはしごを使用していると集まることが出来ない。設定により、集まれないプレイヤーは自爆する。",
+"EvilHackerInfoLong","(Impostors):\nImposter that allows Admin to be seen from anywhere.\nUse the disappear button to move to the Admin location.\nIt can be viewed by pressing the View button at the destination.\nAfter a few seconds it returns to its original position.\nNote that you have to press the View button to see it.\nYou can't move while watching.\n","[インポスター陣営]\n遠隔でアドミンが見れるインポスター。\n消えるボタンでアドミンの位置へ移動します。\n移動先で見るボタンを押す事で見る事ができます。\n数秒後元の位置へと戻ります。\n見るボタンを押さないと見れないので注意。\n見てる最中は動けません。",
 
 "# マッドメイト系役職"
 "Madmate","Madmate","マッドメイト","叛徒","叛徒","Безумец","Tripulante Louco"
@@ -880,6 +883,7 @@ RefusingInfoLong,"(Add-ons):\nOnce he is about to be exiled, refuses to be exile
 "CharismaStarGatherMaxCount","Gather Max Count","集合能力の使用回数",
 "CharismaStarNotGatherPlayerKill","Not Gather Player Kill","集合出来ないプレイヤーは自爆する",
 "CharismaStarCanAllPlayerGather","Can All Player Gather","全員を一気に集合できる"
+"EvilHackerAdminCooldown","Admin Cooldown","アドミンクールダウン",
 
 # マッドメイト
 "CanMakeMadmateCount","Sidekick Madmate Max Count","サイドキックマッドメイト","变形者可以招募叛徒的数量","變形者招募叛徒最大人數","Максимум союзников Безумца","Máximo de Tripulantes Loucos Ajudantes"

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -490,6 +490,7 @@ public enum CustomRoles
     Charger,
     Chaser,
     CharismaStar,
+    EvilHacker,
 
     Godfather,
     Janitor,

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -26,12 +26,26 @@ public sealed class EvilHacker : RoleBase, IImpostor
         player
     )
     {
+        KillCooldown = OptionKillCooldown.GetFloat();
+        AdminCooldown = OptionAdminCooldown.GetFloat();
     }
+    private static OptionItem OptionKillCooldown;
+    private static OptionItem OptionAdminCooldown;
+    private static float KillCooldown;
+    private static float AdminCooldown;
+    public float CalculateKillCooldown() => KillCooldown;
+    public override void ApplyGameOptions(IGameOptions opt) => AURoleOptions.PhantomCooldown = AdminCooldown;
+
     enum OptionName
     {
+        EvilHackerAdminCooldown,
     }
     private static void SetUpOptionItem()
     {
+        OptionKillCooldown = FloatOptionItem.Create(RoleInfo, 10, GeneralOption.KillCooldown, new(2.5f, 180f, 2.5f), 30f, false)
+                .SetValueFormat(OptionFormat.Seconds);
+        OptionAdminCooldown = FloatOptionItem.Create(RoleInfo, 11, OptionName.EvilHackerAdminCooldown, new(2.5f, 180f, 2.5f), 30f, false)
+                .SetValueFormat(OptionFormat.Seconds);
     }
     public override bool OnCheckVanish()
     {

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -73,6 +73,7 @@ public sealed class EvilHacker : RoleBase, IImpostor
         // プレイヤーの位置を指定された位置に強制的に変更
         var teleportPosition = GetTeleportPosition();
         Player.SnapToTeleport(teleportPosition);
+        SendRPC(Player.PlayerId);// RPCでクライアントと同期
         Utils.NotifyRoles();
 
         // プレイヤーの足止め
@@ -81,5 +82,18 @@ public sealed class EvilHacker : RoleBase, IImpostor
         Logger.Info($"{Player.GetNameWithRole()} : プレイヤーの足止め", "EvilHacker");
 
         return true;
+    }
+    private void SendRPC(byte targetId)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        using var sender = CreateSender(CustomRPC.EvilHackerWarpSync);
+        sender.Writer.Write(targetId);
+    }
+
+    public override void ReceiveRPC(MessageReader reader, CustomRPC rpcType)
+    {
+        if (rpcType != CustomRPC.EvilHackerWarpSync) return;
+
+        var targetId = reader.ReadByte();
     }
 }

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using AmongUs.GameOptions;
+
+using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Interfaces;
+using Hazel;
+
+namespace TownOfHostY.Roles.Impostor;
+public sealed class EvilHacker : RoleBase, IImpostor
+{
+    public static readonly SimpleRoleInfo RoleInfo =
+        SimpleRoleInfo.Create(
+            typeof(EvilHacker),
+            player => new EvilHacker(player),
+            CustomRoles.EvilHacker,
+            () => RoleTypes.Phantom,
+            CustomRoleTypes.Impostor,
+            //(int)Options.offsetId.ImpSpecial + 1900,
+            (int)Options.offsetId.ImpY + 1900,
+            SetUpOptionItem,
+            "イビルハッカー"
+        );
+    public EvilHacker(PlayerControl player)
+    : base(
+        RoleInfo,
+        player
+    )
+    {
+    }
+    enum OptionName
+    {
+    }
+    private static void SetUpOptionItem()
+    {
+    }
+    public override bool OnCheckVanish()
+    {
+        return true;
+    }
+}

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -80,7 +80,18 @@ public sealed class EvilHacker : RoleBase, IImpostor
         Main.AllPlayerSpeed[Player.PlayerId] = Main.MinSpeed;
         Player.MarkDirtySettings();
         Logger.Info($"{Player.GetNameWithRole()} : プレイヤーの足止め", "EvilHacker");
-
+        _ = new LateTask(() =>
+                {
+                    Player.SnapToTeleport(LastPosition);//元の位置へ。
+                    SendRPC(Player.PlayerId);
+                    Utils.NotifyRoles();
+                    // ターゲットの足止め解除
+                    Main.AllPlayerSpeed[Player.PlayerId] = Main.RealOptionsData.GetFloat(FloatOptionNames.PlayerSpeedMod);
+                    Player.MarkDirtySettings();
+                    Logger.Info($"{Player.GetNameWithRole()} : プレイヤーの足止め解除", "EvilHacker");
+                    LastPosition = default;
+                    Player.RpcResetAbilityCooldown();
+                }, 2.5f, "ReturnPosition");
         return true;
     }
     private void SendRPC(byte targetId)

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -35,7 +35,7 @@ public sealed class EvilHacker : RoleBase, IImpostor
     private static float AdminCooldown;
     public float CalculateKillCooldown() => KillCooldown;
     public override void ApplyGameOptions(IGameOptions opt) => AURoleOptions.PhantomCooldown = AdminCooldown;
-
+    private Vector2 LastPosition; // 元の位置を保存する変数
     enum OptionName
     {
         EvilHackerAdminCooldown,
@@ -46,6 +46,24 @@ public sealed class EvilHacker : RoleBase, IImpostor
                 .SetValueFormat(OptionFormat.Seconds);
         OptionAdminCooldown = FloatOptionItem.Create(RoleInfo, 11, OptionName.EvilHackerAdminCooldown, new(2.5f, 180f, 2.5f), 30f, false)
                 .SetValueFormat(OptionFormat.Seconds);
+    }
+    private Vector2 GetTeleportPosition()
+    {
+        // マップに応じた座標を選択
+        switch ((MapNames)Main.NormalOptions.MapId)
+        {
+            case MapNames.Airship:
+                return new Vector2(-22.13f, 0.56f);
+            case MapNames.Skeld:
+                return new Vector2(2.96f, -8.62f);
+            case MapNames.Polus:
+                return new Vector2(22.63f, -21.75f);
+            case MapNames.Mira:
+                return new Vector2(22.22f, 18.77f);
+            default:
+                // デフォルトの座標（必要に応じて設定）
+                return new Vector2(0f, 0f);
+        }
     }
     public override bool OnCheckVanish()
     {

--- a/Roles/Impostor/Y/EvilHacker.cs
+++ b/Roles/Impostor/Y/EvilHacker.cs
@@ -67,6 +67,19 @@ public sealed class EvilHacker : RoleBase, IImpostor
     }
     public override bool OnCheckVanish()
     {
+        // 移動前の位置を保持
+        LastPosition = Player.GetTruePosition();
+
+        // プレイヤーの位置を指定された位置に強制的に変更
+        var teleportPosition = GetTeleportPosition();
+        Player.SnapToTeleport(teleportPosition);
+        Utils.NotifyRoles();
+
+        // プレイヤーの足止め
+        Main.AllPlayerSpeed[Player.PlayerId] = Main.MinSpeed;
+        Player.MarkDirtySettings();
+        Logger.Info($"{Player.GetNameWithRole()} : プレイヤーの足止め", "EvilHacker");
+
         return true;
     }
 }


### PR DESCRIPTION
＃ イビルハッカー
判定：Phantom
陣営：インポスター
設定項目
　キルクールダウン
　アドミンクールダウン

アドミンを遠隔で見れるインポスター役職。
消えるボタンでアドミン前に移動します。

<処理の流れ>
透明化する
プレイヤーを動けなくする
アドミンへワープ
元の位置へ戻る
プレイヤーを動けるようにする

　⚠アドミン前にワープするが自分自身でアドミンを
　使用するボタンを押す必要があります。
＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿

<まだできていない事。。。>
ファングルにアドミンがないのでわかないようにしてほしいです。
たしかメアーがわかない設定だったと思われます()

string付近は変更して全然大丈夫です○