### PR TITLE
役職アサイン方法を変更する

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -80,22 +80,27 @@ namespace TownOfHostY
             {
                 remaining = type;
                 list = Main.AllAlivePlayerControls.Where(pc => pc.PlayerId != ExiledPlayerId && IsRecognizeType(pc, type)).ToList();
-                Logger.Info($"SetRoleChange type: {type}, count: {list.Count}, exiled: {ExiledPlayerId}", "AntiBlackout");
+                Logger.Info($"CheckRoleCount type: {remaining}, count: {list.Count}, exiled: {ExiledPlayerId}", "AntiBlackout");
                 if (list.Count > 0) break;
             }
 
             if (remaining <= recognizeType) return;
             recognizeType = remaining;
 
-            Logger.Info($"SetRoleChange count:{list.Count}", "AntiBlackout");
+            Logger.Info($"SetDummyImpostor type: {recognizeType}, count:{list.Count}", "AntiBlackout");
             foreach (var pc in Main.AllPlayerControls.Where(x => !x.Data.Disconnected))
             {
                 if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
                 if (pc.IsAlive() && pc.GetCustomRole().GetRoleInfo().IsDesyncImpostor) continue;
-                foreach (var desync in list)
+                foreach (var dummy in list)
                 {
-                    desync.RpcSetRoleDesync(RoleTypes.Impostor, pc.GetClientId());
+                    dummy.RpcSetRoleDesync(RoleTypes.Impostor, pc.GetClientId());
                 }
+                foreach (var dead in Main.AllDeadPlayerControls.Where(x => !x.Data.Disconnected))
+                {
+                    dead.RpcSetRoleDesync(RoleTypes.CrewmateGhost, pc.GetClientId());
+                }
+                Logger.Info($"SetDummyImpostor player: {pc?.name}", "AntiBlackout");
             }
             ExiledPlayerId = -1;
         }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -25,7 +25,7 @@ namespace TownOfHostY
         private static Dictionary<byte, (bool isDead, bool Disconnected)> isDeadCache = new();
         private readonly static LogHandler logger = Logger.Handler("AntiBlackout");
 
-        private static CountTypes recognizeImpostor = CountTypes.Impostor;
+        private static RecognizeType recognizeType = RecognizeType.Impostor;
         public static int ExiledPlayerId = -1;
 
         public static void SetIsDead(bool doSend = true, [CallerMemberName] string callerMethodName = "")
@@ -49,21 +49,43 @@ namespace TownOfHostY
             IsCached = true;
             if (doSend) SendGameData();
         }
+        private enum RecognizeType
+        {
+            Impostor,
+            StrayWolf,
+            Jackal,
+            Pirate,
+        }
+        private static bool IsRecognizeType(PlayerControl pc, RecognizeType type)
+        {
+            if (pc == null) return false;
+            var customRole = pc.GetCustomRole();
+            var countType = customRole.GetRoleInfo().CountType;
+            return type switch
+            {
+                RecognizeType.Impostor => countType == CountTypes.Impostor && customRole != CustomRoles.StrayWolf,
+                RecognizeType.StrayWolf => countType == CountTypes.Impostor && customRole == CustomRoles.StrayWolf,
+                RecognizeType.Jackal => countType == CountTypes.Jackal,
+                RecognizeType.Pirate => countType == CountTypes.Pirate,
+                _ => false,
+            };
+        }
         private static void SetRoleChange()
         {
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default) return;
 
-            CountTypes countType = CountTypes.None;
+            RecognizeType remaining = RecognizeType.Impostor;
             List<PlayerControl> list = new();
-            foreach (var type in new List<CountTypes>{ CountTypes.Impostor, CountTypes.Jackal, CountTypes.Pirate })
+            foreach (RecognizeType type in Enum.GetValues(typeof(RecognizeType)))
             {
-                list = Main.AllAlivePlayerControls.Where(x => x.GetCustomRole().GetRoleInfo().CountType == type && x.PlayerId != ExiledPlayerId).ToList();
+                remaining = type;
+                list = Main.AllAlivePlayerControls.Where(pc => pc.PlayerId != ExiledPlayerId && IsRecognizeType(pc, type)).ToList();
                 Logger.Info($"SetRoleChange type: {type}, count: {list.Count}, exiled: {ExiledPlayerId}", "AntiBlackout");
                 if (list.Count > 0) break;
             }
 
-            if (countType <= recognizeImpostor) return;
-            recognizeImpostor = countType;
+            if (remaining <= recognizeType) return;
+            recognizeType = remaining;
 
             Logger.Info($"SetRoleChange count:{list.Count}", "AntiBlackout");
             foreach (var pc in Main.AllPlayerControls.Where(x => !x.Data.Disconnected))
@@ -144,7 +166,7 @@ namespace TownOfHostY
             if (isDeadCache == null) isDeadCache = new();
             isDeadCache.Clear();
             IsCached = false;
-            recognizeImpostor = CountTypes.Impostor;
+            recognizeType = RecognizeType.Impostor;
         }
     }
 }

--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -19,7 +19,7 @@ namespace TownOfHostY
         ///<summary>
         ///追放処理を上書きするかどうか
         ///</summary>
-        public static bool OverrideExiledPlayer => Options.NoGameEnd.GetBool() || Jackal.RoleInfo.IsEnable|| StrayWolf.RoleInfo.IsEnable || Options.IsCCMode;
+        public static bool OverrideExiledPlayer => Options.NoGameEnd.GetBool() || Jackal.RoleInfo.IsEnable || StrayWolf.RoleInfo.IsEnable || Options.IsCCMode;
 
         public static bool IsCached { get; private set; } = false;
         private static Dictionary<byte, (bool isDead, bool Disconnected)> isDeadCache = new();
@@ -60,7 +60,9 @@ namespace TownOfHostY
         {
             if (pc == null) return false;
             var customRole = pc.GetCustomRole();
-            var countType = customRole.GetRoleInfo().CountType;
+            var countType = PlayerState.GetByPlayerId(pc.PlayerId).CountType;
+            //var countType = customRole.GetRoleInfo().CountType;
+            Logger.Info($"RecognizeType {pc?.name}, {countType}, {customRole}({customRole.GetRoleInfo().CountType})", "AntiBlackout");
             return type switch
             {
                 RecognizeType.Impostor => countType == CountTypes.Impostor && customRole != CustomRoles.StrayWolf,

--- a/Patches/OutroPatch.cs
+++ b/Patches/OutroPatch.cs
@@ -26,7 +26,6 @@ namespace TownOfHostY
 
             Logger.Info("-----------ゲーム終了-----------", "Phase");
             if (!GameStates.IsModHost) return;
-            if (Main.tempImpostorNum > 0) Main.NormalOptions.NumImpostors = Main.tempImpostorNum;
             SummaryText = new();
             foreach (var id in PlayerState.AllPlayerStates.Keys)
                 SummaryText[id] = Utils.SummaryTexts(id, false);

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -841,7 +841,7 @@ namespace TownOfHostY
     {
         public static bool Prefix(PlayerControl __instance, ref RoleTypes roleType, bool canOverrideRole)
         {
-            if (SelectRolesPatch.RpcSetRoleReplacer.DoReplace()) return true;
+            if (RpcSetRoleReplacer.DoReplace()) return true;
 
             var target = __instance;
             var targetName = __instance.GetNameWithRole();

--- a/Patches/onGameStartedCCModePatch.cs
+++ b/Patches/onGameStartedCCModePatch.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using AmongUs.GameOptions;
+using HarmonyLib;
+
+using TownOfHostY.Modules;
+using TownOfHostY.Roles;
+using TownOfHostY.Roles.Core;
+
+namespace TownOfHostY;
+
+[HarmonyPatch(typeof(RoleManager), nameof(RoleManager.SelectRoles))]
+class SelectRolesCCModePatch
+{
+    public static bool Prefix(RoleManager __instance)
+    {
+        if (!AmongUsClient.Instance.AmHost) return false;
+
+        //CCMode用
+        if (!Options.IsCCMode) return false;
+
+        //CustomRpcSenderとRpcSetRoleReplacerの初期化
+        RpcSetRoleReplacer.StartReplace();
+
+        RoleAssignManager.SelectAssignRoles();
+
+        Dictionary<RoleTypes, int> roleTypesList = new();
+        var assignedNum = 0;
+        var assignedNumImpostors = 0;
+
+        if (CatchCat.Option.T_CanUseVent.GetBool())
+        { // Engineer Setting
+            int CatCount = Main.AllPlayerControls.Count() - 2 - CustomRoles.CCYellowLeader.GetCount();
+            roleTypesList.Add(RoleTypes.Engineer, CatCount);
+        }
+        List<PlayerControl> AllPlayers = new();
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            AllPlayers.Add(pc);
+        }
+
+        if (Options.EnableGM.GetBool())
+        {
+            AllPlayers.RemoveAll(x => x == PlayerControl.LocalPlayer);
+            PlayerControl.LocalPlayer.RpcSetCustomRole(CustomRoles.GM);
+            PlayerControl.LocalPlayer.RpcSetRole(RoleTypes.Crewmate);
+        }
+
+        SelectRolesPatch.AssignDesyncRole(CustomRoles.CCYellowLeader, AllPlayers, ref assignedNum, BaseRole: RoleTypes.Impostor);
+        SelectRolesPatch.AssignDesyncRole(CustomRoles.CCBlueLeader, AllPlayers, ref assignedNum, BaseRole: RoleTypes.Impostor);
+
+        //バニラの役職割り当て
+        SelectRolesPatch.AssignRolesNormal(roleTypesList, assignedNumImpostors);
+
+        //MODの役職割り当て
+        RpcSetRoleReplacer.Release(); //保存していたSetRoleRpcを一気に書く
+
+        var roleTypePlayers = SelectRolesPatch.GetRoleTypePlayers();
+        //役職設定処理
+        //Impostorsを割り当て
+        {
+            SetColorPatch.IsAntiGlitchDisabled = true;
+            if (roleTypePlayers.TryGetValue(RoleTypes.Impostor, out var list))
+            {
+                foreach (var imp in list)
+                {
+                    PlayerState.GetByPlayerId(imp.PlayerId).SetMainRole(CustomRoles.CCRedLeader);
+                    Logger.Info("役職設定:" + imp?.Data?.PlayerName + " = " + CustomRoles.CCRedLeader.ToString(), "AssignRoles");
+                }
+            }
+        }
+        //残りを割り当て
+        {
+            if (roleTypePlayers.TryGetValue(CatchCat.Option.T_CanUseVent.GetBool() ? RoleTypes.Engineer : RoleTypes.Crewmate, out var list))
+            {
+                foreach (var crew in list)
+                {
+                    PlayerState.GetByPlayerId(crew.PlayerId).SetMainRole(CustomRoles.CCNoCat);
+                    Logger.Info("役職設定:" + crew?.Data?.PlayerName + " = " + CustomRoles.CCNoCat.ToString(), "AssignRoles");
+                }
+            }
+            SetColorPatch.IsAntiGlitchDisabled = false;
+        }
+
+        foreach (var pair in PlayerState.AllPlayerStates)
+        {
+            //RPCによる同期
+            ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value.MainRole);
+        }
+
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            HudManager.Instance.SetHudActive(true);
+            Main.AllPlayerKillCooldown[pc.PlayerId] = Options.DefaultKillCooldown; //キルクールをデフォルトキルクールに変更
+
+            CatchCat.Common.Add(pc);
+        }
+        GameEndChecker.SetPredicateToCatchCat();
+
+        GameOptionsSender.AllSenders.Clear();
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            GameOptionsSender.AllSenders.Add(
+                new PlayerGameOptionsSender(pc)
+            );
+        }
+
+        Utils.CountAlivePlayers(true);
+        Utils.SyncAllSettings();
+        SetColorPatch.IsAntiGlitchDisabled = false;
+
+        return false;
+    }
+}

--- a/Patches/onGameStartedHASModePatch.cs
+++ b/Patches/onGameStartedHASModePatch.cs
@@ -1,0 +1,62 @@
+using AmongUs.GameOptions;
+using HarmonyLib;
+
+using TownOfHostY.Roles;
+using TownOfHostY.Roles.Core;
+
+namespace TownOfHostY;
+
+[HarmonyPatch(typeof(RoleManager), nameof(RoleManager.SelectRoles))]
+class SelectRolesHASModePatch
+{
+    public static bool Prefix(RoleManager __instance)
+    {
+        if (!AmongUsClient.Instance.AmHost) return false;
+
+        //HideAndSeek用
+        if (!Options.IsHASMode) return false;
+
+        //CustomRpcSenderとRpcSetRoleReplacerの初期化
+        RpcSetRoleReplacer.StartReplace();
+
+        RoleAssignManager.SelectAssignRoles();
+
+        //バニラの役職割り当て
+        SelectRolesPatch.AssignRolesNormal(null, 0);
+
+        //MODの役職割り当て
+        RpcSetRoleReplacer.Release(); //保存していたSetRoleRpcを一気に書く
+
+        SetColorPatch.IsAntiGlitchDisabled = true;
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            if (pc.Is(CustomRoleTypes.Impostor))
+                pc.RpcSetColor(0);
+            else if (pc.Is(CustomRoleTypes.Crewmate))
+                pc.RpcSetColor(1);
+        }
+
+        var roleTypePlayers = SelectRolesPatch.GetRoleTypePlayers();
+        //役職設定処理
+        if (roleTypePlayers.TryGetValue(RoleTypes.Crewmate, out var list))
+        {
+            SelectRolesPatch.AssignCustomRolesFromList(CustomRoles.HASFox, list);
+            SelectRolesPatch.AssignCustomRolesFromList(CustomRoles.HASTroll, list);
+        }
+        foreach (var pair in PlayerState.AllPlayerStates)
+        {
+            //RPCによる同期
+            ExtendedPlayerControl.RpcSetCustomRole(pair.Key, pair.Value.MainRole);
+        }
+        //色設定処理
+        SetColorPatch.IsAntiGlitchDisabled = true;
+
+        GameEndChecker.SetPredicateToHideAndSeek();
+
+        Utils.CountAlivePlayers(true);
+        Utils.SyncAllSettings();
+        SetColorPatch.IsAntiGlitchDisabled = false;
+
+        return false;
+    }
+}

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -696,6 +696,7 @@ class SelectRolesPatch
         }
         return count;
     }
+}
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSetRole)), HarmonyPriority(Priority.High)]
     public class RpcSetRoleReplacer
     {
@@ -856,4 +857,3 @@ class SelectRolesPatch
             StoragedData = null;
         }
     }
-}

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -153,7 +153,6 @@ class SelectRolesPatch
         var assignedNum = 0;
         var assignedNumImpostors = 0;
 
-
         foreach (var roleTypes in new RoleTypes[] { RoleTypes.Scientist, RoleTypes.Engineer, RoleTypes.Tracker, RoleTypes.Noisemaker, RoleTypes.Shapeshifter, RoleTypes.Phantom })
         {
             roleTypesList.Add(roleTypes, GetRoleTypesCount(roleTypes));
@@ -187,7 +186,7 @@ class SelectRolesPatch
                         break;
                 }
 
-            AssignDesyncRole(role, AllPlayers, ref assignedNum, BaseRole: info.BaseRoleType.Invoke());
+                AssignDesyncRole(role, AllPlayers, ref assignedNum, BaseRole: info.BaseRoleType.Invoke());
             }
         }
 
@@ -221,23 +220,15 @@ class SelectRolesPatch
         }
         if (!CustomRoles.PlatonicLover.IsEnable() && CustomRoles.Lovers.IsEnable())
             AssignCustomSubRolesFromList(CustomRoles.Lovers, allPlayersbySub, 2);
-        AssignCustomSubRolesFromList(CustomRoles.AddWatch, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Sunglasses, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.AddLight, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.AddSeer, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Autopsy, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.VIP, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Clumsy, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Revenger, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Management, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.InfoPoor, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Sending, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.TieBreaker, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.NonReport, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.PlusVote, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Guarding, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.AddBait, allPlayersbySub);
-        AssignCustomSubRolesFromList(CustomRoles.Refusing, allPlayersbySub);
+        foreach (var role in new CustomRoles[] { CustomRoles.AddWatch, CustomRoles.Sunglasses, CustomRoles.AddLight,
+                                                   CustomRoles.AddSeer, CustomRoles.Autopsy, CustomRoles.VIP,
+                                                   CustomRoles.Clumsy, CustomRoles.Revenger, CustomRoles.Management,
+                                                   CustomRoles.InfoPoor, CustomRoles.Sending, CustomRoles.TieBreaker,
+                                                   CustomRoles.NonReport, CustomRoles.PlusVote, CustomRoles.Guarding,
+                                                   CustomRoles.AddBait, CustomRoles.Refusing })
+        {
+            AssignCustomSubRolesFromList(role, allPlayersbySub);
+        }
 
         foreach (var pair in PlayerState.AllPlayerStates)
         {
@@ -512,163 +503,163 @@ class SelectRolesPatch
         return roleTypePlayers;
     }
 }
-    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSetRole)), HarmonyPriority(Priority.High)]
-    public class RpcSetRoleReplacer
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSetRole)), HarmonyPriority(Priority.High)]
+public class RpcSetRoleReplacer
+{
+    private static bool doReplace = false;
+    private static Dictionary<byte, CustomRpcSender> senders;
+    public static List<(PlayerControl, RoleTypes)> StoragedData = new();
+    // 役職DesyncなどRolesMapでSetRoleRpcを書き込みするリスト
+    public static List<byte> OverriddenSenderList;
+    public static Dictionary<(byte, byte), RoleTypes> RolesMap;
+    public static bool DoReplace() => doReplace;
+
+    public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] RoleTypes roleType)
     {
-        private static bool doReplace = false;
-        private static Dictionary<byte, CustomRpcSender> senders;
-        public static List<(PlayerControl, RoleTypes)> StoragedData = new();
-        // 役職DesyncなどRolesMapでSetRoleRpcを書き込みするリスト
-        public static List<byte> OverriddenSenderList;
-        public static Dictionary<(byte, byte), RoleTypes> RolesMap;
-        public static bool DoReplace() => doReplace;
-
-        public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] RoleTypes roleType)
+        if (doReplace && senders != null)
         {
-            if (doReplace && senders != null)
-            {
-                StoragedData.Add((__instance, roleType));
-                return false;
-            }
-            else return true;
+            StoragedData.Add((__instance, roleType));
+            return false;
         }
-        public static void Release()
+        else return true;
+    }
+    public static void Release()
+    {
+        ReleaseNormalSetRole(true);
+        ReleaseDesyncSetRole(true);
+        senders.Do(kvp => kvp.Value.SendMessage());
+
+        DummySetRole();
+
+        // 不要なオブジェクトの削除
+        EndReplace();
+    }
+    public static void DummySetRole()
+    {
+        foreach (var pc in Main.AllPlayerControls)
         {
-            ReleaseNormalSetRole(true);
-            ReleaseDesyncSetRole(true);
-            senders.Do(kvp => kvp.Value.SendMessage());
-
-            DummySetRole();
-
-            // 不要なオブジェクトの削除
-            EndReplace();
-        }
-        public static void DummySetRole()
-        {
-            foreach (var pc in Main.AllPlayerControls)
-            {
-                if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
-                DummySetRole(pc);
-            }
-        }
-        public static void DummySetRole(PlayerControl target)
-        {
-            int targetClientId = target.GetClientId();
-            if (!RolesMap.TryGetValue((target.PlayerId, target.PlayerId), out var roleType))
-            {
-                roleType = StoragedData.FirstOrDefault(x => x.Item1.PlayerId == target.PlayerId).Item2;
-            }
-            Logger.Info($"sent {target.name} {roleType}", "DummySetRole");
-
-            var stream = MessageWriter.Get(SendOption.Reliable);
-            stream.StartMessage(6);
-            stream.Write(AmongUsClient.Instance.GameId);
-            stream.WritePacked(targetClientId);
-            {
-                SetDisconnectedMessage(stream, true);
-
-                stream.StartMessage(2);
-                stream.WritePacked(target.NetId);
-                stream.Write((byte)RpcCalls.SetRole);
-                stream.Write((ushort)roleType);
-                stream.Write(true);     //canOverrideRole
-                stream.EndMessage();
-                Logger.Info($"DummySetRole to:{target?.name}({targetClientId}) player:{target?.name}({roleType})", "★RpcSetRole");
-
-                SetDisconnectedMessage(stream, false);
-            }
-            stream.EndMessage();
-            AmongUsClient.Instance.SendOrDisconnect(stream);
-            stream.Recycle();
-        }
-        private static void SetDisconnectedMessage(MessageWriter stream, bool disconnected)
-        {
-            foreach (var pc in Main.AllPlayerControls)
-            {
-                //if (pc.PlayerId != target.PlayerId) continue;
-                pc.Data.Disconnected = disconnected;
-
-                stream.StartMessage(1);
-                stream.WritePacked(pc.Data.NetId);
-                pc.Data.Serialize(stream, false);
-                stream.EndMessage();
-            }
-        }
-        private static void ReleaseDesyncSetRole(bool skipSelf)
-        {
-            foreach (var seer in Main.AllPlayerControls)
-            {
-                foreach (var target in Main.AllPlayerControls)
-                {
-                    if (skipSelf && seer.PlayerId == target.PlayerId &&
-                        seer.PlayerId != PlayerControl.LocalPlayer.PlayerId) continue;
-                    if (RolesMap.TryGetValue((seer.PlayerId, target.PlayerId), out var roleType))
-                    {
-                        if (roleType == RoleTypes.Scientist &&
-                            StoragedData.Any(x => x.Item1.PlayerId == seer.PlayerId && x.Item2 == RoleTypes.Noisemaker))
-                        {
-                            Logger.Info($"ChangeNoisemaker seer: {seer.PlayerId}, target: {target.PlayerId},{roleType}=>{RoleTypes.Noisemaker}", "MakeDesyncSender");
-                            roleType = RoleTypes.Noisemaker;
-                        }
-
-                        var sender = senders[seer.PlayerId];
-                        sender.AutoStartRpc(seer.NetId, (byte)RpcCalls.SetRole, target.GetClientId())
-                            .Write((ushort)roleType)
-                            .Write(true) //canOverrideRole
-                            .EndRpc();
-                        Logger.Info($"ReleaseDesyncSetRole to:{target?.name}({target.GetClientId()}) player:{seer?.name}({roleType})", "RpcSetRole");
-                    }
-                }
-            }
-        }
-        private static void ReleaseNormalSetRole(bool skipSelf)
-        {
-            foreach (var senderPair in senders)
-            {
-                var sender = senderPair.Value;
-                var targetId = senderPair.Key;
-                if (OverriddenSenderList.Contains(targetId)) continue;
-                if (sender.CurrentState != CustomRpcSender.State.InRootMessage)
-                    throw new InvalidOperationException("A CustomRpcSender had Invalid State.");
-
-                foreach (var pair in StoragedData)
-                {
-                    if (skipSelf && targetId == pair.Item1.PlayerId &&
-                        targetId != PlayerControl.LocalPlayer.PlayerId) continue;
-
-                    var player = pair.Item1;
-                    var roleType = pair.Item2;
-                    var clientId = Utils.GetPlayerById(targetId).GetClientId();
-
-                    player.StartCoroutine(player.CoSetRole(roleType, false));
-                    sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetRole, clientId)
-                        .Write((ushort)roleType)
-                        .Write(true)           //canOverrideRole = false
-                        .EndRpc();
-                    Logger.Info($"ReleaseNormalSetRole toClientId:{clientId} player:{player?.name}({roleType})", "RpcSetRole");
-                }
-                sender.EndMessage();
-            }
-            doReplace = false;
-        }
-        public static void StartReplace()
-        {
-            senders = new();
-            foreach (var pc in Main.AllPlayerControls)
-            {
-                senders[pc.PlayerId] = new CustomRpcSender($"{pc.name}'s SetRole Sender", SendOption.Reliable, false)
-                        .StartMessage(pc.GetClientId());
-            }
-            StoragedData = new();
-            OverriddenSenderList = new();
-            RolesMap = new();
-            doReplace = true;
-        }
-        public static void EndReplace()
-        {
-            senders = null;
-            OverriddenSenderList = null;
-            RolesMap = null;
-            StoragedData = null;
+            if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
+            DummySetRole(pc);
         }
     }
+    public static void DummySetRole(PlayerControl target)
+    {
+        int targetClientId = target.GetClientId();
+        if (!RolesMap.TryGetValue((target.PlayerId, target.PlayerId), out var roleType))
+        {
+            roleType = StoragedData.FirstOrDefault(x => x.Item1.PlayerId == target.PlayerId).Item2;
+        }
+        Logger.Info($"sent {target.name} {roleType}", "DummySetRole");
+
+        var stream = MessageWriter.Get(SendOption.Reliable);
+        stream.StartMessage(6);
+        stream.Write(AmongUsClient.Instance.GameId);
+        stream.WritePacked(targetClientId);
+        {
+            SetDisconnectedMessage(stream, true);
+
+            stream.StartMessage(2);
+            stream.WritePacked(target.NetId);
+            stream.Write((byte)RpcCalls.SetRole);
+            stream.Write((ushort)roleType);
+            stream.Write(true);     //canOverrideRole
+            stream.EndMessage();
+            Logger.Info($"DummySetRole to:{target?.name}({targetClientId}) player:{target?.name}({roleType})", "★RpcSetRole");
+
+            SetDisconnectedMessage(stream, false);
+        }
+        stream.EndMessage();
+        AmongUsClient.Instance.SendOrDisconnect(stream);
+        stream.Recycle();
+    }
+    private static void SetDisconnectedMessage(MessageWriter stream, bool disconnected)
+    {
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            //if (pc.PlayerId != target.PlayerId) continue;
+            pc.Data.Disconnected = disconnected;
+
+            stream.StartMessage(1);
+            stream.WritePacked(pc.Data.NetId);
+            pc.Data.Serialize(stream, false);
+            stream.EndMessage();
+        }
+    }
+    private static void ReleaseDesyncSetRole(bool skipSelf)
+    {
+        foreach (var seer in Main.AllPlayerControls)
+        {
+            foreach (var target in Main.AllPlayerControls)
+            {
+                if (skipSelf && seer.PlayerId == target.PlayerId &&
+                    seer.PlayerId != PlayerControl.LocalPlayer.PlayerId) continue;
+                if (RolesMap.TryGetValue((seer.PlayerId, target.PlayerId), out var roleType))
+                {
+                    if (roleType == RoleTypes.Scientist &&
+                        StoragedData.Any(x => x.Item1.PlayerId == seer.PlayerId && x.Item2 == RoleTypes.Noisemaker))
+                    {
+                        Logger.Info($"ChangeNoisemaker seer: {seer.PlayerId}, target: {target.PlayerId},{roleType}=>{RoleTypes.Noisemaker}", "MakeDesyncSender");
+                        roleType = RoleTypes.Noisemaker;
+                    }
+
+                    var sender = senders[seer.PlayerId];
+                    sender.AutoStartRpc(seer.NetId, (byte)RpcCalls.SetRole, target.GetClientId())
+                        .Write((ushort)roleType)
+                        .Write(true) //canOverrideRole
+                        .EndRpc();
+                    Logger.Info($"ReleaseDesyncSetRole to:{target?.name}({target.GetClientId()}) player:{seer?.name}({roleType})", "RpcSetRole");
+                }
+            }
+        }
+    }
+    private static void ReleaseNormalSetRole(bool skipSelf)
+    {
+        foreach (var senderPair in senders)
+        {
+            var sender = senderPair.Value;
+            var targetId = senderPair.Key;
+            if (OverriddenSenderList.Contains(targetId)) continue;
+            if (sender.CurrentState != CustomRpcSender.State.InRootMessage)
+                throw new InvalidOperationException("A CustomRpcSender had Invalid State.");
+
+            foreach (var pair in StoragedData)
+            {
+                if (skipSelf && targetId == pair.Item1.PlayerId &&
+                    targetId != PlayerControl.LocalPlayer.PlayerId) continue;
+
+                var player = pair.Item1;
+                var roleType = pair.Item2;
+                var clientId = Utils.GetPlayerById(targetId).GetClientId();
+
+                player.StartCoroutine(player.CoSetRole(roleType, false));
+                sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetRole, clientId)
+                    .Write((ushort)roleType)
+                    .Write(true)           //canOverrideRole = false
+                    .EndRpc();
+                Logger.Info($"ReleaseNormalSetRole toClientId:{clientId} player:{player?.name}({roleType})", "RpcSetRole");
+            }
+            sender.EndMessage();
+        }
+        doReplace = false;
+    }
+    public static void StartReplace()
+    {
+        senders = new();
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            senders[pc.PlayerId] = new CustomRpcSender($"{pc.name}'s SetRole Sender", SendOption.Reliable, false)
+                    .StartMessage(pc.GetClientId());
+        }
+        StoragedData = new();
+        OverriddenSenderList = new();
+        RolesMap = new();
+        doReplace = true;
+    }
+    public static void EndReplace()
+    {
+        senders = null;
+        OverriddenSenderList = null;
+        RolesMap = null;
+        StoragedData = null;
+    }
+}

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -148,11 +148,10 @@ class SelectRolesPatch
 
         RoleAssignManager.SelectAssignRoles();
 
-        Dictionary<RoleTypes, int> roleTypesList = new();
-
         var assignedNum = 0;
         var assignedNumImpostors = 0;
 
+        Dictionary<RoleTypes, int> roleTypesList = new();
         foreach (var roleTypes in new RoleTypes[] { RoleTypes.Scientist, RoleTypes.Engineer, RoleTypes.Tracker, RoleTypes.Noisemaker, RoleTypes.Shapeshifter, RoleTypes.Phantom })
         {
             roleTypesList.Add(roleTypes, GetRoleTypesCount(roleTypes));

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -168,7 +168,6 @@ class SelectRolesPatch
                 AllPlayers.RemoveAll(x => x == PlayerControl.LocalPlayer);
                 PlayerControl.LocalPlayer.RpcSetCustomRole(CustomRoles.GM);
                 PlayerControl.LocalPlayer.RpcSetRole(RoleTypes.Crewmate);
-                PlayerControl.LocalPlayer.Data.IsDead = true;
             }
 
             AssignDesyncRole(CustomRoles.CCYellowLeader, AllPlayers, ref assignedNum, BaseRole: RoleTypes.Impostor);
@@ -189,7 +188,6 @@ class SelectRolesPatch
         //        AllPlayers.RemoveAll(x => x == PlayerControl.LocalPlayer);
         //        PlayerControl.LocalPlayer.RpcSetCustomRole(CustomRoles.GM);
         //        PlayerControl.LocalPlayer.RpcSetRole(RoleTypes.Crewmate);
-        //        PlayerControl.LocalPlayer.Data.IsDead = true;
         //    }
 
         //    Dictionary<(byte, byte), RoleTypes> rolesMap = new();
@@ -217,7 +215,6 @@ class SelectRolesPatch
                 AllPlayers.RemoveAll(x => x == PlayerControl.LocalPlayer);
                 PlayerControl.LocalPlayer.RpcSetRole(RoleTypes.Crewmate);
                 PlayerState.GetByPlayerId(PlayerControl.LocalPlayer.PlayerId).SetMainRole(CustomRoles.GM);
-                PlayerControl.LocalPlayer.Data.IsDead = true;
             }
             foreach (var (role, info) in CustomRoleManager.AllRolesInfo)
             {
@@ -263,7 +260,6 @@ class SelectRolesPatch
 
         foreach (var pc in Main.AllPlayerControls)
         {
-            pc.Data.IsDead = false; //プレイヤーの死を解除する
 
             if (!pc.Is(CustomRoles.GM)) allPlayersbySub.Add(pc);
 
@@ -572,7 +568,8 @@ class SelectRolesPatch
     {
         var list = AmongUsClient.Instance.allClients.ToArray()
         .Where(c => c.Character != null && c.Character.Data != null &&
-                    !c.Character.Data.Disconnected && !c.Character.Data.IsDead)
+                    !c.Character.Data.Disconnected && !c.Character.Data.IsDead &&
+                    PlayerState.GetByPlayerId(c.Character.PlayerId).MainRole == CustomRoles.NotAssigned)
         .OrderBy(c => c.Id).Select(c => c.Character.Data).ToList();
         int adjustedNumImpostors = Main.NormalOptions.GetInt(Int32OptionNames.NumImpostors) - assignedNumImpostors;
         Logger.Info($"NomalAssign list: {list.Count}, impostor: {adjustedNumImpostors}(desync: {assignedNumImpostors})", "AssignRoles");
@@ -666,7 +663,6 @@ class SelectRolesPatch
             RpcSetRoleReplacer.OverriddenSenderList.Add(player.PlayerId);
             //ホスト視点はロール決定
             player.StartCoroutine(player.CoSetRole(othersRole, false));
-            player.Data.IsDead = true;
             assignedNum++;
 
             Logger.Info("役職設定(desync):" + player?.Data?.PlayerName + " = " + role.ToString(), "AssignRoles");

--- a/Roles/Neutral/Jackal/JSidekick.cs
+++ b/Roles/Neutral/Jackal/JSidekick.cs
@@ -20,6 +20,7 @@ public sealed class JSidekick : RoleBase, IKiller, ISchrodingerCatOwner
             SetupOptionItem,
             "サイドキック",
             "#00b4eb",
+            true,
             countType: CountTypes.Jackal
         );
     public JSidekick(PlayerControl player)

--- a/main.cs
+++ b/main.cs
@@ -130,8 +130,6 @@ namespace TownOfHostY
 
         public static Main Instance;
 
-        public static int tempImpostorNum = 0;
-
         public override void Load()
         {
             Instance = this;


### PR DESCRIPTION
・役職アサインで死亡状態を使用しないようにする
　※ゲーム開始時に死亡状態で始まる不具合の対応
・CCモード、HASモードの役職割り当てを別クラス化する
・暗転防止機能の処理、陣営判定を修正、適正化する
・役職アサイン処理のリファクタリング
