### PR TITLE
bugfix) 累積的不具合の対応

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -72,7 +72,8 @@ namespace TownOfHostY
         }
         public static InnerNet.ClientData GetClient(this PlayerControl player)
         {
-            return AmongUsClient.Instance.allClients.ToArray().FirstOrDefault(cd => cd.Character.PlayerId == player.PlayerId);
+            if (player == null) return null;
+            return AmongUsClient.Instance.allClients.ToArray().FirstOrDefault(cd => cd != null && cd.Character != null && cd.Character.PlayerId == player.PlayerId);
         }
         public static int GetClientId(this PlayerControl player)
         {

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -90,21 +90,13 @@ namespace TownOfHostY
         }
         public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData data, [HarmonyArgument(1)] DisconnectReasons reason)
         {
+            if (data == null || data.Character == null) return;
+
             var isFailure = false;
 
             try
             {
-                if (data == null)
-                {
-                    isFailure = true;
-                    Logger.Warn("退出者のClientDataがnull", nameof(OnPlayerLeftPatch));
-                }
-                else if (data.Character == null)
-                {
-                    isFailure = true;
-                    Logger.Warn("退出者のPlayerControlがnull", nameof(OnPlayerLeftPatch));
-                }
-                else if (data.Character.Data == null)
+                if (data.Character.Data == null)
                 {
                     isFailure = true;
                     Logger.Warn("退出者のPlayerInfoがnull", nameof(OnPlayerLeftPatch));

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -79,6 +79,8 @@ namespace TownOfHostY
     {
         static void Prefix([HarmonyArgument(0)] ClientData data)
         {
+            if (data == null || data.Character == null) return;
+
             if (CustomRoles.Executioner.IsPresent())
                 Executioner.ChangeRoleByTarget(data.Character.PlayerId);
             if (CustomRoles.Lawyer.IsPresent())

--- a/Roles/Neutral/Jackal/Jackal.cs
+++ b/Roles/Neutral/Jackal/Jackal.cs
@@ -132,7 +132,7 @@ namespace TownOfHostY.Roles.Neutral
                 roleTypes = RoleTypes.Scientist;
                 if (pc.PlayerId == sidekick.PlayerId) roleTypes = RoleTypes.Impostor;
                 else if (!pc.IsAlive()) roleTypes = RoleTypes.CrewmateGhost;
-                else if (pc.GetCustomRole().GetRoleInfo().CountType == CountTypes.Jackal) roleTypes = RoleTypes.Impostor;
+                else if (pc.GetCustomRole().GetRoleInfo()?.CountType == CountTypes.Jackal) roleTypes = RoleTypes.Impostor;
                 else if (pc.GetCustomRole().GetRoleTypes() == RoleTypes.Noisemaker) roleTypes = RoleTypes.Noisemaker;
 
                 if (sidekick.PlayerId == PlayerControl.LocalPlayer.PlayerId) pc.StartCoroutine(pc.CoSetRole(roleTypes, true));
@@ -142,7 +142,7 @@ namespace TownOfHostY.Roles.Neutral
 
                 //他クルー視点
                 roleTypes = RoleTypes.Scientist;
-                if (pc.GetCustomRole().GetRoleInfo().CountType == CountTypes.Jackal) roleTypes = RoleTypes.Impostor;
+                if (pc.GetCustomRole().GetRoleInfo()?.CountType == CountTypes.Jackal) roleTypes = RoleTypes.Impostor;
 
                 if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId) sidekick.StartCoroutine(sidekick.CoSetRole(roleTypes, true));
                 else sidekick.RpcSetRoleDesync(roleTypes, pc.GetClientId());

--- a/Roles/RoleAssignManager.cs
+++ b/Roles/RoleAssignManager.cs
@@ -140,7 +140,7 @@ namespace TownOfHostY.Roles
                 if (numImpostorsLeft <= 0 && numOthersLeft <= 0) break;
 
                 var targetRoles = role.GetAssignUnitRolesArray();
-                var numImpostorAssign = targetRoles.Count(role => role.IsImpostor());
+                var numImpostorAssign = targetRoles.Count(role => role.GetAssignRoleType() == CustomRoleTypes.Impostor);
                 var numOthersAssign = targetRoles.Length - numImpostorAssign;
                 //アサイン枠が足りてない場合
                 if (numImpostorAssign > numImpostorsLeft


### PR DESCRIPTION
累積的不具合の対応
・GMとジャッカルが配役されたときにサイドキックが正しく動作しない不具合を解消する
　　ロールクラス無しの役職とジャッカルの組み合わせ処理を修正
・停電サボタージュ同期ずれ解消用の通信を行う
　　停電妨害禁止の場合に同期ずれにより停電が直らない不具合の対応
・PlayerControl.GetClientのnull値でエラーにならないようにする
　　入室時キックされた場合に内部エラーになる不具合の対応
・OnPlayerLeftPatchでクライアントキック時にPlayerControl=nullをエラーとして処理しないようにする
　　入室時キックされた場合に表示エラーになる不具合の対応
・固定アサインの場合にインポスター以外でインポスターカウントする役職を正しい属性でカウントするように修正
　　エゴイストが配役されたときに全役職配役されない場合がある不具合の対応