### PR TITLE
bugfix) 累積的不具合の対応/ゲッサーの指定先追加

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -11,6 +11,7 @@ using TownOfHostY.Roles.Impostor;
 using TownOfHostY.Roles.Neutral;
 using System.ComponentModel;
 using TownOfHostY.Roles.Core;
+using TownOfHostY.Roles.Core.Interfaces;
 
 namespace TownOfHostY
 {
@@ -86,7 +87,19 @@ namespace TownOfHostY
                 if (list.Count > 0) break;
             }
 
-            if (remaining <= recognizeType) return;
+            if (remaining <= recognizeType)
+            {
+                foreach (var dead in Main.AllDeadPlayerControls.Where(x => !x.Data.Disconnected))
+                {
+                    if (dead.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
+                    if (dead.CanUseSabotageButton())
+                    {
+                        dead.RpcSetRoleDesync(RoleTypes.CrewmateGhost, dead.GetClientId());
+                        Logger.Info($"SetDummyCrewmateGhost player: {dead?.name}", "AntiBlackout");
+                    }
+                }
+                return;
+            }
             recognizeType = remaining;
 
             Logger.Info($"SetDummyImpostor type: {recognizeType}, count:{list.Count}", "AntiBlackout");
@@ -121,6 +134,16 @@ namespace TownOfHostY
             isDeadCache.Clear();
             IsCached = false;
             if (doSend) SendGameData();
+
+            foreach (var dead in Main.AllDeadPlayerControls.Where(x => !x.Data.Disconnected))
+            {
+                if (dead.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
+                if (dead.CanUseSabotageButton())
+                {
+                    dead.RpcSetRoleDesync(RoleTypes.ImpostorGhost, dead.GetClientId());
+                    Logger.Info($"SetDummyImpostorGhost player: {dead?.name}", "AntiBlackout");
+                }
+            }
         }
 
         public static void SendGameData([CallerMemberName] string callerMethodName = "")

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -339,6 +339,8 @@ public abstract class VoteGuesser : RoleBase
             {
                 case CustomRoles.ChainShifter: return ChainShifter.AdditionalRoles;
                 case CustomRoles.Jackal: return Jackal.AdditionalRoles;
+                case CustomRoles.Executioner: return Executioner.AdditionalRoles;
+                case CustomRoles.Lawyer: return Lawyer.AdditionalRoles;
             }
 
             return [];

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -321,8 +321,11 @@ public abstract class VoteGuesser : RoleBase
             var inChainShifter = false;
             foreach (CustomRoles role in CustomRolesHelper.AllStandardRoles.Where(r => r.IsEnable()))
             {
-                if (role is CustomRoles.LastImpostor or CustomRoles.Lovers or CustomRoles.Workhorse) continue;
-                roleList.Add(role);
+                foreach (var targetRole in role.GetRoleAssignInfo()?.AssignUnitRoles)
+                {
+                    if (targetRole != CustomRoles.Crewmate && targetRole != CustomRoles.Impostor &&
+                        !roleList.Contains(targetRole)) roleList.Add(targetRole);
+                }
                 if (role == CustomRoles.ChainShifter) inChainShifter = true;
             }
             if (inChainShifter)

--- a/Roles/Core/Class/VoteGuesser.cs
+++ b/Roles/Core/Class/VoteGuesser.cs
@@ -326,13 +326,22 @@ public abstract class VoteGuesser : RoleBase
                     if (targetRole != CustomRoles.Crewmate && targetRole != CustomRoles.Impostor &&
                         !roleList.Contains(targetRole)) roleList.Add(targetRole);
                 }
-                if (role == CustomRoles.ChainShifter) inChainShifter = true;
+                foreach (var targetRole in GetAdditionalRole(role))
+                {
+                    if (targetRole != CustomRoles.Crewmate && targetRole != CustomRoles.Impostor &&
+                        !roleList.Contains(targetRole)) roleList.Add(targetRole);
+                }
             }
-            if (inChainShifter)
+        }
+        public CustomRoles[] GetAdditionalRole(CustomRoles role)
             {
-                var role = ChainShifter.ShiftedRole;
-                if (!roleList.Contains(role)) roleList.Add(role);
+            switch (role)
+            {
+                case CustomRoles.ChainShifter: return ChainShifter.AdditionalRoles;
+                case CustomRoles.Jackal: return Jackal.AdditionalRoles;
             }
+
+            return [];
         }
         private void SetDispList()
         {

--- a/Roles/Neutral/Jackal/Jackal.cs
+++ b/Roles/Neutral/Jackal/Jackal.cs
@@ -67,6 +67,7 @@ namespace TownOfHostY.Roles.Neutral
 
         private int canSidekickCount;
         private static List<byte> sidekickTarget = new();
+        public static CustomRoles[] AdditionalRoles => canCreateSidekick ? [CustomRoles.JSidekick] : [];
 
         public SchrodingerCat.TeamType SchrodingerCatChangeTo => SchrodingerCat.TeamType.Jackal;
 

--- a/Roles/Neutral/Jackal/Jackal.cs
+++ b/Roles/Neutral/Jackal/Jackal.cs
@@ -152,6 +152,7 @@ namespace TownOfHostY.Roles.Neutral
 
             //サイドキック⇔ジャッカル色表示
             NameColorManager.Add(jackal.PlayerId, sidekick.PlayerId, jackal.GetRoleColorCode());
+            NameColorManager.RemoveAll(sidekick.PlayerId);
             NameColorManager.Add(sidekick.PlayerId, jackal.PlayerId, jackal.GetRoleColorCode());
 
             PlayerGameOptionsSender.SetDirty(Player.PlayerId);

--- a/Roles/Neutral/Lawyer/Lawyer.cs
+++ b/Roles/Neutral/Lawyer/Lawyer.cs
@@ -67,6 +67,7 @@ public sealed class Lawyer : RoleBase
 
     private static HashSet<Lawyer> Lawyers = new(15);
     private PlayerControl Target = null;
+    public static CustomRoles[] AdditionalRoles => [CustomRoles.Pursuer];
 
     private static void SetupOptionItem()
     {

--- a/Roles/Neutral/TOH/Executioner.cs
+++ b/Roles/Neutral/TOH/Executioner.cs
@@ -56,6 +56,7 @@ public sealed class Executioner : RoleBase, IAdditionalWinner
     public static HashSet<Executioner> Executioners = new(15);
     public byte TargetId;
     private bool TargetExiled;
+    public static CustomRoles[] AdditionalRoles => [ChangeRolesAfterTargetKilled];
     public static readonly CustomRoles[] ChangeRoles =
     {
             CustomRoles.Crewmate, CustomRoles.Jester, CustomRoles.Opportunist,

--- a/Roles/Neutral/Y/ChainShifter.cs
+++ b/Roles/Neutral/Y/ChainShifter.cs
@@ -51,6 +51,8 @@ public sealed class ChainShifter : RoleBase
     public static float ShiftInactiveTime;
     public static CustomRoles ShiftedRole = CustomRoles.Opportunist;
     public static bool ShiftWhenKilled;
+
+    public static CustomRoles[] AdditionalRoles => [ShiftedRole];
     enum OptionName
     {
         ChainShifterShiftTime,

--- a/Roles/RoleAssignManager.cs
+++ b/Roles/RoleAssignManager.cs
@@ -306,7 +306,7 @@ namespace TownOfHostY.Roles
             }
             return candidateRoleList;
         }
-        private static RoleAssignInfo GetRoleAssignInfo(this CustomRoles role) =>
+        public static RoleAssignInfo GetRoleAssignInfo(this CustomRoles role) =>
             CustomRoleManager.GetRoleInfo(role)?.AssignInfo;
         private static CustomRoleTypes GetAssignRoleType(this CustomRoles role) =>
             role.GetRoleAssignInfo()?.AssignRoleType ?? role.GetCustomRoleTypes();


### PR DESCRIPTION
累積的不具合の対応
・サボタージュができる役職が死亡後にサボタージュができなくなる不具合を解消
・ホストのVanish処理が正しくできない不具合を解消
　ホストが透明化ボタンを使用した後、正常に動作できない問題
・ゲッサーの指定先にクルーメイトが含まれる場合がある不具合を解消
・ジャッカルにサイドキックされたとき元の役職でみえていた名前の色をクリアする
　設定されたNameColorをすべてクリアする（GM、ワーカホリック、虹色スターの再設定不要）

ゲッサーの指定先追加
・ゲッサーの指定先にユニット役職を追加
・ゲッサーの対象に、役職変更がある場合の変更先役職を追加
　（チェインシフター、ジャッカル、エクスキューショナー、弁護士）