### PR TITLE
タスク・属性の割り当てと会議後の暗転に関する修正

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -154,7 +154,7 @@ public static class AntiBlackout
         var targetClientId = player.GetClientId();
         if (targetClientId == -1) return;
 
-        
+
         var playerRoleInfo = player.GetCustomRole().GetRoleInfo();
         bool viewerIsDesync = playerRoleInfo?.IsDesyncImpostor ?? false;
 
@@ -169,10 +169,10 @@ public static class AntiBlackout
             var roleInfo = customRole.GetRoleInfo();
             bool isAlive = pc.IsAlive();
 
-            
+
             var role = roleInfo?.BaseRoleType?.Invoke() ?? RoleTypes.Scientist;
 
-            
+
             if (!isAlive)
             {
                 role = (customRole.IsImpostor() || customRole.IsMadmate()
@@ -181,11 +181,11 @@ public static class AntiBlackout
                     : RoleTypes.CrewmateGhost;
             }
 
-            
+
             if (player.PlayerId != pc.PlayerId && (roleInfo?.IsDesyncImpostor ?? false))
                 role = isAlive ? RoleTypes.Crewmate : RoleTypes.CrewmateGhost;
 
-            
+
             RoleTypes setrole = (viewerIsDesync && player.PlayerId != pc.PlayerId)
                 ? (isAlive ? RoleTypes.Crewmate : RoleTypes.CrewmateGhost)
                 : role;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -37,8 +37,9 @@ static class ExtendedPlayerControl
         else if (role > CustomRoles.StartAddon)
         {
             PlayerState.GetByPlayerId(player.PlayerId).SetSubRole(role);
-            return;
+            
         }
+
         if (AmongUsClient.Instance.AmHost)
         {
             if (role < CustomRoles.StartAddon)
@@ -830,7 +831,7 @@ static class ExtendedPlayerControl
 
         foreach (var player in GameData.Instance.AllPlayers)
         {
-            
+
             if (writer.Length > 400)
             {
                 writer.EndMessage();
@@ -851,7 +852,7 @@ static class ExtendedPlayerControl
                 }
             }
 
-            writer.StartMessage(1); 
+            writer.StartMessage(1);
             writer.WritePacked(player.NetId);
             player.Serialize(writer, false);
             writer.EndMessage();

--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -40,7 +40,7 @@ namespace TownOfHostY.Modules
         }
         public void SetDirty() => IsDirty = true;
 
-        public override void SendGameOptions()  
+        public override void SendGameOptions()
         {
             if (player.AmOwner)
             {
@@ -50,7 +50,8 @@ namespace TownOfHostY.Modules
                     if (com.TryCast<LogicOptions>(out var lo))
                     {
                         lo.SetGameOptions(opt);
-                        lo.ClearDirtyFlag(); 
+                        lo.ClearDirtyFlag();
+                    }
                 }
                 GameOptionsManager.Instance.CurrentGameOptions = opt;
             }
@@ -85,13 +86,16 @@ namespace TownOfHostY.Modules
             var opt = BasedGameOptions;
             AURoleOptions.SetOpt(opt);
             var state = PlayerState.GetByPlayerId(player.PlayerId);
-            // Restore() は既にロビーの正しい視界値を opt に書き込んでいる。
-            // IsBlackOut=false の時は DefaultCrewmateVision による上書きを行わず Restore の値をそのまま使う。
-            // IsBlackOut=true の時のみ視界を 0 にする。
+            Logger.Info($"[VisionDebug] {player?.Data?.PlayerName}: IsBlackOut={state.IsBlackOut}, DefaultCrewVision={Main.DefaultCrewmateVision}, RestoreCrewVision={opt.GetFloat(FloatOptionNames.CrewLightMod)}", "BuildGameOptions");
             if (state.IsBlackOut)
             {
                 opt.SetFloat(FloatOptionNames.CrewLightMod, 0f);
                 opt.SetFloat(FloatOptionNames.ImpostorLightMod, 0f);
+            }
+            else
+            {
+                opt.SetFloat(FloatOptionNames.CrewLightMod, Main.DefaultCrewmateVision);
+                opt.SetFloat(FloatOptionNames.ImpostorLightMod, Main.DefaultImpostorVision);
             }
 
             CustomRoles role = player.GetCustomRole();
@@ -116,17 +120,13 @@ namespace TownOfHostY.Modules
 
             var roleClass = player.GetRoleClass();
             roleClass?.ApplyGameOptions(opt);
-            // 暗転中は視界変更系の属性を適用しない（BlackOut を上書きしてしまうため）
-            if (!state.IsBlackOut)
+            foreach (var subRole in player.GetCustomSubRoles())
             {
-                foreach (var subRole in player.GetCustomSubRoles())
+                switch (subRole)
                 {
-                    switch (subRole)
-                    {
-                        case CustomRoles.AddWatch: AddWatch.ApplyGameOptions(opt); break;
-                        case CustomRoles.AddLight: AddLight.ApplyGameOptions(opt); break;
-                        case CustomRoles.Sunglasses: Sunglasses.ApplyGameOptions(opt); break;
-                    }
+                    case CustomRoles.AddWatch: AddWatch.ApplyGameOptions(opt); break;
+                    case CustomRoles.AddLight: AddLight.ApplyGameOptions(opt); break;
+                    case CustomRoles.Sunglasses: Sunglasses.ApplyGameOptions(opt); break;
                 }
             }
             Blinder.ApplyGameOptionsByOther(player.PlayerId, opt);

--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -48,7 +48,9 @@ namespace TownOfHostY.Modules
                 foreach (var com in GameManager.Instance.LogicComponents)
                 {
                     if (com.TryCast<LogicOptions>(out var lo))
+                    {
                         lo.SetGameOptions(opt);
+                        lo.ClearDirtyFlag(); 
                 }
                 GameOptionsManager.Instance.CurrentGameOptions = opt;
             }
@@ -83,7 +85,14 @@ namespace TownOfHostY.Modules
             var opt = BasedGameOptions;
             AURoleOptions.SetOpt(opt);
             var state = PlayerState.GetByPlayerId(player.PlayerId);
-            opt.BlackOut(state.IsBlackOut);
+            // Restore() は既にロビーの正しい視界値を opt に書き込んでいる。
+            // IsBlackOut=false の時は DefaultCrewmateVision による上書きを行わず Restore の値をそのまま使う。
+            // IsBlackOut=true の時のみ視界を 0 にする。
+            if (state.IsBlackOut)
+            {
+                opt.SetFloat(FloatOptionNames.CrewLightMod, 0f);
+                opt.SetFloat(FloatOptionNames.ImpostorLightMod, 0f);
+            }
 
             CustomRoles role = player.GetCustomRole();
             switch (role.GetCustomRoleTypes())
@@ -107,13 +116,17 @@ namespace TownOfHostY.Modules
 
             var roleClass = player.GetRoleClass();
             roleClass?.ApplyGameOptions(opt);
-            foreach (var subRole in player.GetCustomSubRoles())
+            // 暗転中は視界変更系の属性を適用しない（BlackOut を上書きしてしまうため）
+            if (!state.IsBlackOut)
             {
-                switch (subRole)
+                foreach (var subRole in player.GetCustomSubRoles())
                 {
-                    case CustomRoles.AddWatch: AddWatch.ApplyGameOptions(opt); break;
-                    case CustomRoles.AddLight: AddLight.ApplyGameOptions(opt); break;
-                    case CustomRoles.Sunglasses: Sunglasses.ApplyGameOptions(opt); break;
+                    switch (subRole)
+                    {
+                        case CustomRoles.AddWatch: AddWatch.ApplyGameOptions(opt); break;
+                        case CustomRoles.AddLight: AddLight.ApplyGameOptions(opt); break;
+                        case CustomRoles.Sunglasses: Sunglasses.ApplyGameOptions(opt); break;
+                    }
                 }
             }
             Blinder.ApplyGameOptionsByOther(player.PlayerId, opt);

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -45,7 +45,7 @@ namespace TownOfHostY
         SetLawyerTarget,
         SetRemoveLawyerTarget,
         EvilHackerWarpSync,
-        SyncPsychicResult,  
+        SyncPsychicResult,
     }
     public enum Sounds
     {
@@ -180,7 +180,7 @@ namespace TownOfHostY
                     byte killerId = reader.ReadByte();
                     RPC.SetRealKiller(targetId, killerId);
                     break;
-                case CustomRPC.SyncPsychicResult:                    
+                case CustomRPC.SyncPsychicResult:
                     CustomRoleManager.DispatchRpc(reader, rpcType);
                     break;
                 default:
@@ -283,21 +283,19 @@ namespace TownOfHostY
         }
         public static void SetCustomRole(byte targetId, CustomRoles role)
         {
-            var roleClass = CustomRoleManager.GetByPlayerId(targetId);
-            if (roleClass != null)
-            {
-                var player = roleClass.Player;
-                roleClass.Dispose();
-                CustomRoleManager.CreateInstance(role, player);
-            }
-
             if (role < CustomRoles.StartAddon)
             {
+                
+                var roleClass = CustomRoleManager.GetByPlayerId(targetId);
+                if (roleClass != null)
+                {
+                    roleClass.Dispose();
+                }
                 PlayerState.GetByPlayerId(targetId).SetMainRole(role);
                 CustomRoleManager.CreateInstance(role, Utils.GetPlayerById(targetId));
             }
             else if (role > CustomRoles.StartAddon)
-            {
+            {               
                 PlayerState.GetByPlayerId(targetId).SetSubRole(role);
             }
 

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -618,6 +618,12 @@ namespace TownOfHostY
             Logger.Info($"sender: {sender?.name}, sendTo: {sendTo}", "SendCustomChat");
             string command = "\n\n";
             sender = PlayerControl.LocalPlayer;
+            // ホストが死亡している場合は生存しているプレイヤーに送らせる
+            if (sender.Data.IsDead && GameStates.IsInGame)
+            {
+                var aliveSender = Main.AllAlivePlayerControls.FirstOrDefault();
+                if (aliveSender != null) sender = aliveSender;
+            }
             string name = sender.Data?.PlayerName;
             int clientId = sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
             if (clientId == -1)

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -70,7 +70,7 @@ namespace TownOfHostY
                 Sending.OnExileWrapUp(exiled.Object);
 
                 if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) PlayerState.GetByPlayerId(exiled.PlayerId).SetDead();
-            }            
+            }
             // ランダムスポーン
             switch ((MapNames)Main.NormalOptions.MapId)
             {
@@ -102,7 +102,6 @@ namespace TownOfHostY
             FallFromLadder.Reset();
             Utils.CountAlivePlayers(true);
             Utils.AfterMeetingTasks();
-            Utils.SyncAllSettings();
             Utils.NotifyRoles();
         }
 
@@ -149,7 +148,7 @@ namespace TownOfHostY
                     Main.AfterMeetingDeathPlayers.Clear();
                 }, 0.5f, "AfterMeetingDeathPlayers Task");
 
-               
+
                 _ = new LateTask(() =>
                 {
                     Main.AllPlayerControls.Do(pc => AntiBlackout.ResetSetRole(pc));
@@ -160,9 +159,13 @@ namespace TownOfHostY
                     if (CustomWinnerHolder.WinnerTeam is not CustomWinner.Default) return;
                     foreach (var pc in Main.AllPlayerControls)
                     {
+                        var state = PlayerState.GetByPlayerId(pc.PlayerId);
+                        state.IsBlackOut = false;
                         pc.ResetKillCooldown();
                         pc.SetKillCooldown(ForceProtect: true);
+                        pc.MarkDirtySettings();
                     }
+                    Utils.SyncAllSettings();
                 }, 1.0f, "AfterMeeting_SetKillCooldown");
             }
 

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -103,6 +103,7 @@ namespace TownOfHostY
             Utils.CountAlivePlayers(true);
             Utils.AfterMeetingTasks();
             Utils.NotifyRoles();
+            Utils.SyncAllSettings();
         }
 
         static void WrapUpFinalizer(NetworkedPlayerInfo exiled)

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -327,6 +327,7 @@ public static class MeetingHudPatch
             if (AmongUsClient.Instance.AmHost)
             {
                 if (!AntiBlackout.IsCached) AntiBlackout.SetIsDead();
+                Utils.AfterMeetingTasks();
 
                 Main.AllPlayerControls.Where(pc => !pc.Is(CustomRoles.GM)).Do(pc => RandomSpawn.CustomNetworkTransformPatch.FirstTP[pc.PlayerId] = true);
 

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -30,7 +30,11 @@ namespace TownOfHostY
                     if (player.Is(CustomRoles.GM)) return; //GMは対象外に
                     if (FirstTP[player.PlayerId])
                     {
-                        FirstTP[player.PlayerId] = false;
+                        FirstTP[player.PlayerId] = false;                                                
+                        var state = PlayerState.GetByPlayerId(player.PlayerId);
+                        state.IsBlackOut = false;
+                        player.SyncSettings();
+
                         if (Main.NormalOptions.MapId != 4) return; //マップがエアシップじゃなかったらreturn
                         player.RpcResetAbilityCooldown();
                         if (Options.FixFirstKillCooldown.GetBool() && MeetingStates.FirstMeeting)

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -14,279 +14,159 @@ namespace TownOfHostY
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.AddTasksFromList))]
     class AddTasksFromListPatch
     {
-
         public static void Prefix(ShipStatus __instance,
-            [HarmonyArgument(4)] ref Il2CppSystem.Collections.Generic.List<NormalPlayerTask> unusedTasks)
+            [HarmonyArgument(4)] Il2CppSystem.Collections.Generic.List<NormalPlayerTask> unusedTasks)
         {
             if (!AmongUsClient.Instance.AmHost) return;
+
             if (!Options.DisableTasks.GetBool()) return;
-
-            if (unusedTasks == null)
-            {
-                Logger.Warn("unusedTasks が null です - タスク無効化をスキップします", "AddTasksFromListPatch");
-                return;
-            }
-
-            Logger.Info($"AddTasksFromList called. incoming unusedTasks.Count={unusedTasks.Count}", "AddTasksFromListPatch");
-
-
-            var filtered = new Il2CppSystem.Collections.Generic.List<NormalPlayerTask>();
-            var removedTypes = new List<TaskTypes>();
+            List<NormalPlayerTask> disabledTasks = new();
             for (var i = 0; i < unusedTasks.Count; i++)
             {
                 var task = unusedTasks[i];
-                if (task == null) continue;
-
-                bool isDisabled = false;
-                if (task.TaskType == TaskTypes.SwipeCard && Options.DisableSwipeCard.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.SubmitScan && Options.DisableSubmitScan.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.UnlockSafe && Options.DisableUnlockSafe.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.UploadData && Options.DisableUploadData.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.StartReactor && Options.DisableStartReactor.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.ResetBreakers && Options.DisableResetBreaker.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.RewindTapes && Options.DisableRewindTapes.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.VentCleaning && Options.DisableVentCleaning.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.BuildSandcastle && Options.DisableBuildSandcastle.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.TestFrisbee && Options.DisableTestFrisbee.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.WaterPlants && Options.DisableWaterPlants.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.CatchFish && Options.DisableCatchFish.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.HelpCritter && Options.DisableHelpCritter.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.TuneRadio && Options.DisableTuneRadio.GetBool()) isDisabled = true;
-                if (task.TaskType == TaskTypes.AssembleArtifact && Options.DisableAssembleArtifact.GetBool()) isDisabled = true;
-
-                if (isDisabled)
-                {
-                    removedTypes.Add(task.TaskType);
-                }
-
-                if (!isDisabled)
-                {
-                    filtered.Add(task);
-                }
+                if (task.TaskType == TaskTypes.SwipeCard && Options.DisableSwipeCard.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.SubmitScan && Options.DisableSubmitScan.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.UnlockSafe && Options.DisableUnlockSafe.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.UploadData && Options.DisableUploadData.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.StartReactor && Options.DisableStartReactor.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.ResetBreakers && Options.DisableResetBreaker.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.RewindTapes && Options.DisableRewindTapes.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.VentCleaning && Options.DisableVentCleaning.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.BuildSandcastle && Options.DisableBuildSandcastle.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.TestFrisbee && Options.DisableTestFrisbee.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.WaterPlants && Options.DisableWaterPlants.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.CatchFish && Options.DisableCatchFish.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.HelpCritter && Options.DisableHelpCritter.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.TuneRadio && Options.DisableTuneRadio.GetBool()) disabledTasks.Add(task);
+                if (task.TaskType == TaskTypes.AssembleArtifact && Options.DisableAssembleArtifact.GetBool()) disabledTasks.Add(task);
             }
-
-            Logger.Info($"AddTasksFromList: kept={filtered.Count}, removed={removedTypes.Count}", "AddTasksFromListPatch");
-            if (removedTypes.Count > 0)
-            {
-                Logger.Info($"Removed task types: {string.Join(",", removedTypes)}", "AddTasksFromListPatch");
+            foreach (var task in disabledTasks)
+            {               
+                unusedTasks.Remove(task);
             }
-
-            // Replace the original list reference with the filtered one so the original method
-            // iterates over a safe list that doesn't contain disabled tasks.
-            unusedTasks = filtered;
         }
     }
 
     [HarmonyPatch(typeof(NetworkedPlayerInfo), nameof(NetworkedPlayerInfo.RpcSetTasks))]
     class RpcSetTasksPatch
     {
-
+       
+        public static bool SkipPatch = false;
         public static Il2CppSystem.Collections.Generic.Dictionary<byte, Il2CppStructArray<byte>> taskIds = new();
 
         public static void Prefix(NetworkedPlayerInfo __instance,
-            [HarmonyArgument(0)] ref Il2CppStructArray<byte> taskTypeIds)
+        [HarmonyArgument(0)] ref Il2CppStructArray<byte> taskTypeIds)
         {
-            try
-            {
-                // ゲーム状態チェック
-                if (Main.RealOptionsData == null)
-                {
-                    Logger.Error("CRITICAL: RealOptionsData が null です - ゲーム状態が破損しています", "RpcSetTasksPatch");
-                    AmongUsClient.Instance.ExitGame(DisconnectReasons.ExitGame);
-                    return;
-                }
-
-                if (__instance == null)
-                {
-                    Logger.Error("NetworkedPlayerInfo が null です", "RpcSetTasksPatch");
-                    return;
-                }
-
-                var pc = Utils.GetPlayerById(__instance.PlayerId);
-                if (pc == null)
-                {
-                    Logger.Warn($"PlayerId {__instance.PlayerId} のプレイヤーが見つかりません", "RpcSetTasksPatch");
-                    return;
-                }
+           
+            if (SkipPatch) return;
 
 
-                if (Options.CurrentGameMode == CustomGameMode.Standard && !Main.IsroleAssigned)
-                {
-                    Logger.Info($"RpcSetTasks (pre-role): {pc.name} をキャッシュしてスキップ", "RpcSetTasksPatch");
-                    if (taskTypeIds != null)
-                        taskIds[__instance.PlayerId] = taskTypeIds;
-                    taskTypeIds = new Il2CppStructArray<byte>(0);
-                    return;
-                }
-
-                Logger.Info($"RpcSetTasks called for player {pc.GetNameWithRole()} (id={pc.PlayerId}) incoming taskTypeIds.Count={(taskTypeIds == null ? 0 : taskTypeIds.Count)}", "RpcSetTasksPatch");
-
-                CustomRoles? RoleNullable = pc.GetCustomRole();
-                if (RoleNullable == null)
-                {
-                    Logger.Warn($"{pc.name} のカスタム役職が null です", "RpcSetTasksPatch");
-                    return;
-                }
-
-                CustomRoles role = RoleNullable.Value;
-
-                // デフォルトのタスク数
-                bool hasCommonTasks = true;
-                int NumLongTasks = Main.NormalOptions != null ? Main.NormalOptions.NumLongTasks : 0;
-                int NumShortTasks = Main.NormalOptions != null ? Main.NormalOptions.NumShortTasks : 0;
-
-                // タスク数オーバーライド
-                if (Options.OverrideTasksData.AllData.TryGetValue(role, out var data) && data.doOverride.GetBool())
-                {
-                    hasCommonTasks = data.assignCommonTasks.GetBool();
-                    NumLongTasks = data.numLongTasks.GetInt();
-                    NumShortTasks = data.numShortTasks.GetInt();
-                    Logger.Info($"OverrideTasks for {pc.name}: hasCommon={hasCommonTasks} long={NumLongTasks} short={NumShortTasks}", "RpcSetTasksPatch");
-                }
-
-                // 固有タスク処理
-                if (pc.Is(CustomRoles.VentManager))
-                    (hasCommonTasks, NumLongTasks, NumShortTasks) = VentManager.TaskData;
-                if (pc.Is(CustomRoles.FoxSpirit))
-                    (hasCommonTasks, NumLongTasks, NumShortTasks) = FoxSpirit.TaskData;
-                if (pc.Is(CustomRoles.Workhorse))
-                    (hasCommonTasks, NumLongTasks, NumShortTasks) = Workhorse.TaskData;
-                if (pc.Is(CustomRoles.Rabbit) && Rabbit.IsFinish(pc))
-                    (hasCommonTasks, NumLongTasks, NumShortTasks) = Rabbit.TaskData;
-
-                if (taskTypeIds == null)
-                {
-                    Logger.Warn($"{pc.name} の taskTypeIds が null です", "RpcSetTasksPatch");
-                    return;
-                }
-
-                int defaultCommonTasksNum = Main.RealOptionsData.GetInt(Int32OptionNames.NumCommonTasks);
-
-                if (taskTypeIds.Count == 0) hasCommonTasks = false;
-                if (!hasCommonTasks && NumLongTasks == 0 && NumShortTasks == 0 && defaultCommonTasksNum == 0) NumShortTasks = 1;
-
-                Il2CppSystem.Collections.Generic.List<byte> TasksList = new();
-                foreach (var num in taskTypeIds) TasksList.Add(num);
-
-                Logger.Info($"Initial TasksList count={TasksList.Count} hasCommonTasks={hasCommonTasks}", "RpcSetTasksPatch");
-
-                if (hasCommonTasks)
-                {
-                    int removeStart = defaultCommonTasksNum;
-                    int removeCount = TasksList.Count - defaultCommonTasksNum;
-                    if (removeStart >= 0 && removeStart < TasksList.Count && removeCount > 0)
-                        TasksList.RemoveRange(removeStart, removeCount);
-                    Logger.Info($"After trimming common tasks TasksList count={TasksList.Count}", "RpcSetTasksPatch");
-                }
-                else
-                {
-                    TasksList.Clear();
-                    Logger.Info($"Cleared common tasks for {pc.name}", "RpcSetTasksPatch");
-                }
-
-                if (ShipStatus.Instance == null)
-                {
-                    Logger.Error("ShipStatus が null です - タスク割り当てをスキップします", "RpcSetTasksPatch");
-                    return;
-                }
-
-                var LongTasks = new Il2CppSystem.Collections.Generic.List<NormalPlayerTask>();
-                if (ShipStatus.Instance.LongTasks != null)
-                {
-                    foreach (var task in ShipStatus.Instance.LongTasks)
-                    {
-                        if (task != null) LongTasks.Add(task);
-                    }
-                    Shuffle(LongTasks);
-                }
-
-                var ShortTasks = new Il2CppSystem.Collections.Generic.List<NormalPlayerTask>();
-                if (ShipStatus.Instance.ShortTasks != null)
-                {
-                    foreach (var task in ShipStatus.Instance.ShortTasks)
-                    {
-                        if (task != null) ShortTasks.Add(task);
-                    }
-                    Shuffle(ShortTasks);
-                }
-
-                Logger.Info($"LongTasks={LongTasks.Count}, ShortTasks={ShortTasks.Count}", "RpcSetTasksPatch");
-
-                int longAdded = 0;
-                foreach (var t in LongTasks)
-                {
-                    if (longAdded >= NumLongTasks) break;
-                    if (t != null)
-                    {
-                        TasksList.Add((byte)t.TaskType);
-                        longAdded++;
-                    }
-                }
-
-                int shortAdded = 0;
-                foreach (var t in ShortTasks)
-                {
-                    if (shortAdded >= NumShortTasks) break;
-                    if (t != null)
-                    {
-                        TasksList.Add((byte)t.TaskType);
-                        shortAdded++;
-                    }
-                }
-
-                Logger.Info($"Added tasks: long={longAdded}, short={shortAdded}", "RpcSetTasksPatch");
-
-
-                if (pc.Is(CustomRoles.VentManager) || pc.Is(CustomRoles.FoxSpirit))
-                {
-                    TasksList.Clear();
-                    ShortTasks.Clear();
-
-                    if (ShipStatus.Instance.ShortTasks != null)
-                    {
-                        var ventTask = ShipStatus.Instance.ShortTasks.FirstOrDefault(t => t != null && t.TaskType == TaskTypes.VentCleaning);
-                        if (ventTask != null) ShortTasks.Add(ventTask);
-                    }
-
-                    if (ShortTasks.Count > 0)
-                    {
-                        bool hasVent = false;
-                        for (int _i = 0; _i < TasksList.Count; _i++)
-                        {
-                            if (TasksList[_i] == (byte)TaskTypes.VentCleaning)
-                            {
-                                hasVent = true;
-                                break;
-                            }
-                        }
-                        if (!hasVent) TasksList.Add((byte)TaskTypes.VentCleaning);
-                    }
-                    Logger.Info($"VentManager/FoxSpirit special handling TasksList count={TasksList.Count}", "RpcSetTasksPatch");
-                }
-
-                // 配列に変換
-                taskTypeIds = new Il2CppStructArray<byte>(TasksList.Count);
-                for (int i = 0; i < TasksList.Count; i++)
-                    taskTypeIds[i] = TasksList[i];
-
-                Logger.Info($"{pc.name} にタスク {TasksList.Count} 個を割り当てました (長: {NumLongTasks}, 短: {NumShortTasks})", "RpcSetTasksPatch");
-            }
-            catch (System.Exception ex)
-            {
-                Logger.Error($"RpcSetTasksPatch で例外が発生しました: {ex.Message}", "RpcSetTasksPatch");
-                Logger.Exception(ex, "RpcSetTasksPatch");
+            if (Main.RealOptionsData == null)
+            {               
                 return;
             }
+
+            var pc = Utils.GetPlayerById(__instance.PlayerId);
+            CustomRoles? RoleNullable = pc?.GetCustomRole();
+            if (RoleNullable == null) return;
+            CustomRoles role = RoleNullable.Value;
+
+            // デフォルトのタスク数
+            bool hasCommonTasks = true;
+            int NumLongTasks = Main.NormalOptions.NumLongTasks;
+            int NumShortTasks = Main.NormalOptions.NumShortTasks;
+
+            if (Options.OverrideTasksData.AllData.TryGetValue(role, out var data) && data.doOverride.GetBool())
+            {
+                hasCommonTasks = data.assignCommonTasks.GetBool();
+                NumLongTasks = data.numLongTasks.GetInt();
+                NumShortTasks = data.numShortTasks.GetInt();
+            }
+
+            if (pc.Is(CustomRoles.VentManager))
+                (hasCommonTasks, NumLongTasks, NumShortTasks) = VentManager.TaskData;
+            if (pc.Is(CustomRoles.FoxSpirit))
+                (hasCommonTasks, NumLongTasks, NumShortTasks) = FoxSpirit.TaskData;
+            if (pc.Is(CustomRoles.Workhorse))
+                (hasCommonTasks, NumLongTasks, NumShortTasks) = Workhorse.TaskData;
+            if (pc.Is(CustomRoles.Rabbit) && Rabbit.IsFinish(pc))
+                (hasCommonTasks, NumLongTasks, NumShortTasks) = Rabbit.TaskData;
+
+            if (taskTypeIds.Count == 0) hasCommonTasks = false;
+            if (!hasCommonTasks && NumLongTasks == 0 && NumShortTasks == 0) NumShortTasks = 1;
+                       
+            if (!pc.Is(CustomRoles.VentManager) && !pc.Is(CustomRoles.FoxSpirit)
+                && hasCommonTasks
+                && NumLongTasks == Main.NormalOptions.NumLongTasks
+                && NumShortTasks == Main.NormalOptions.NumShortTasks)
+            {
+                taskIds[__instance.PlayerId] = taskTypeIds;
+                return;
+            }
+
+            Il2CppSystem.Collections.Generic.List<byte> TasksList = new();
+            foreach (var num in taskTypeIds)
+                TasksList.Add(num);
+
+            int defaultCommonTasksNum = Main.RealOptionsData.GetInt(Int32OptionNames.NumCommonTasks);
+            if (hasCommonTasks) TasksList.RemoveRange(defaultCommonTasksNum, TasksList.Count - defaultCommonTasksNum);
+            else TasksList.Clear();
+
+            Il2CppSystem.Collections.Generic.HashSet<TaskTypes> usedTaskTypes = new();
+            int start2 = 0;
+            int start3 = 0;
+
+            Il2CppSystem.Collections.Generic.List<NormalPlayerTask> LongTasks = new();
+            foreach (var task in ShipStatus.Instance.LongTasks)
+                LongTasks.Add(task);
+            Shuffle<NormalPlayerTask>(LongTasks);
+
+            Il2CppSystem.Collections.Generic.List<NormalPlayerTask> ShortTasks = new();
+            foreach (var task in ShipStatus.Instance.ShortTasks)
+                ShortTasks.Add(task);
+            Shuffle<NormalPlayerTask>(ShortTasks);
+
+           
+            if (pc.Is(CustomRoles.VentManager) || pc.Is(CustomRoles.FoxSpirit))
+            {
+                TasksList.Clear();
+                ShortTasks.Clear();
+
+                var ventTask = ShipStatus.Instance.ShortTasks.FirstOrDefault(task => task.TaskType == TaskTypes.VentCleaning);
+                if (ventTask != null)
+                    ShortTasks.Add(ventTask);              
+            }
+
+            ShipStatus.Instance.AddTasksFromList(
+                ref start2,
+                NumLongTasks,
+                TasksList,
+                usedTaskTypes,
+                LongTasks
+            );
+            ShipStatus.Instance.AddTasksFromList(
+                ref start3,
+                NumShortTasks,
+                TasksList,
+                usedTaskTypes,
+                ShortTasks
+            );
+
+            taskTypeIds = new Il2CppStructArray<byte>(TasksList.Count);
+            for (int i = 0; i < TasksList.Count; i++)
+            {
+                taskTypeIds[i] = TasksList[i];
+            }
+
+            taskIds[__instance.PlayerId] = taskTypeIds;
         }
 
         public static void Shuffle<T>(Il2CppSystem.Collections.Generic.List<T> list)
         {
-            if (list == null || list.Count == 0) return;
-
             for (int i = 0; i < list.Count - 1; i++)
             {
                 T obj = list[i];
-                int rand = UnityEngine.Random.Range(i, list.Count);
+                int rand = IRandom.Instance.Next(i, list.Count);
                 list[i] = list[rand];
                 list[rand] = obj;
             }

--- a/Patches/onGameStartedCCModePatch.cs
+++ b/Patches/onGameStartedCCModePatch.cs
@@ -100,9 +100,13 @@ class SelectRolesCCModePatch
         GameOptionsSender.AllSenders.Clear();
         foreach (var pc in Main.AllPlayerControls)
         {
-            GameOptionsSender.AllSenders.Add(
-                new PlayerGameOptionsSender(pc)
-            );
+            if (!pc.AmOwner)
+                GameOptionsSender.AllSenders.Add(new PlayerGameOptionsSender(pc));
+        }
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            if (pc.AmOwner)
+                GameOptionsSender.AllSenders.Add(new PlayerGameOptionsSender(pc));
         }
 
         Utils.CountAlivePlayers(true);

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -266,6 +266,7 @@ class SelectRolesPatch
         {
             if (UnassignedPlayers.Count == 0) break;
 
+            if (customRole > CustomRoles.StartAddon) continue;
 
             var roleInfo = CustomRoleManager.GetRoleInfo(customRole);
             if (roleInfo != null && roleInfo.IsDesyncImpostor) continue;
@@ -483,7 +484,7 @@ class SelectRolesPatch
             CustomRoles.NonReport, CustomRoles.PlusVote, CustomRoles.Guarding,
             CustomRoles.AddBait, CustomRoles.Refusing, CustomRoles.Revealer })
         {
-            AssignCustomSubRolesFromList(role, allPlayersbySub);
+            AssignCustomSubRolesDuplicatable(role, allPlayersbySub);
         }
 
         foreach (var pair in PlayerState.AllPlayerStates)
@@ -722,6 +723,38 @@ class SelectRolesPatch
         return AssignedPlayers;
     }
 
+
+    private static void AssignCustomSubRolesDuplicatable(CustomRoles role, List<PlayerControl> allPlayersbySub)
+    {
+        if (allPlayersbySub == null || allPlayersbySub.Count <= 0) return;
+        var count = role.GetCount();
+        if (count <= 0) return;
+        var chance = role.GetChance();
+        if (chance <= 0) return;
+
+        var rand = IRandom.Instance;
+        int assigned = 0;
+        int attempts = 0;
+        int maxAttempts = count * 10;
+        var unassigned = allPlayersbySub.Where(pc => !pc.GetCustomSubRoles().Contains(role)).ToList();
+
+        while (assigned < count && attempts < maxAttempts)
+        {
+            attempts++;
+            if (chance < 100 && rand.Next(100) >= chance) continue;
+
+
+            if (unassigned.Count == 0) unassigned = new List<PlayerControl>(allPlayersbySub);
+            if (unassigned.Count == 0) break;
+
+            var player = unassigned[rand.Next(0, unassigned.Count)];
+            unassigned.Remove(player);
+            PlayerState.GetByPlayerId(player.PlayerId).SetSubRole(role);
+            Logger.Info("属性設定:" + player?.Data?.PlayerName + " = " + player.GetCustomRole().ToString() + " + " + role.ToString(), "AssignSubRoles");
+            assigned++;
+        }
+    }
+
     private static List<PlayerControl> AssignCustomSubRolesFromList(CustomRoles role, List<PlayerControl> allPlayersbySub, int RawCount = -1)
     {
         if (allPlayersbySub == null || allPlayersbySub.Count <= 0) return null;
@@ -858,8 +891,7 @@ public static class StandardIntroHelper
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-
-
+        HudManagerCoShowIntroPatch.Cancel = false;
 
         GameDataSerializePatch.DontTouch = false;
         GameDataSerializePatch.SerializeMessageCount++;
@@ -888,7 +920,7 @@ public static class StandardIntroHelper
         {
             i++;
             data.Disconnected = false;
-            if (i > 4) continue;            
+            if (i > 4) continue;
             var pc = Utils.GetPlayerById(data.PlayerId);
             var isDesync = pc?.GetCustomRole().GetRoleInfo()?.IsDesyncImpostor == true;
             var originalRole = data.Role?.Role ?? RoleTypes.Crewmate;
@@ -959,6 +991,7 @@ public static class StandardIntroHelper
 
                 _ = new LateTask(() =>
                 {
+                    RpcSetTasksPatch.SkipPatch = true;
                     foreach (var pc in Main.AllPlayerControls)
                     {
                         if (RpcSetTasksPatch.taskIds.TryGetValue(pc.PlayerId, out var taskids))
@@ -969,6 +1002,7 @@ public static class StandardIntroHelper
                             pc.Data.RpcSetTasks(new Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppStructArray<byte>(0));
                         }
                     }
+                    RpcSetTasksPatch.SkipPatch = false;
                     foreach (var pc in Main.AllPlayerControls)
                         PlayerState.GetByPlayerId(pc.PlayerId).InitTask(pc);
                     GameData.Instance.RecomputeTaskCounts();
@@ -1094,7 +1128,7 @@ public static class StandardIntroHelper
 
         _ = new LateTask(() =>
         {
-
+            HudManagerCoShowIntroPatch.Cancel = false;
 
             foreach (var pc in Main.AllPlayerControls)
             {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -537,9 +537,13 @@ class SelectRolesPatch
         GameOptionsSender.AllSenders.Clear();
         foreach (var pc in Main.AllPlayerControls)
         {
-            GameOptionsSender.AllSenders.Add(
-                new PlayerGameOptionsSender(pc)
-            );
+            if (!pc.AmOwner)
+                GameOptionsSender.AllSenders.Add(new PlayerGameOptionsSender(pc));
+        }
+        foreach (var pc in Main.AllPlayerControls)
+        {
+            if (pc.AmOwner)
+                GameOptionsSender.AllSenders.Add(new PlayerGameOptionsSender(pc));
         }
 
         Utils.CountAlivePlayers(true);

--- a/Roles/RoleAssignManager.cs
+++ b/Roles/RoleAssignManager.cs
@@ -280,6 +280,8 @@ namespace TownOfHostY.Roles
         {
             foreach (var subRole in CustomRolesHelper.AllAddOnRoles)
             {
+                if (subRole.IsFirstWriteAddOn()) continue;
+
                 var chance = subRole.GetChance();
                 var count = subRole.GetAssignCount();
                 if (chance == 0 || count == 0) continue;


### PR DESCRIPTION
以下の問題の修正が含まれます
・タスクが正常に割り当てられない問題
・属性が正常に割り当てられない問題
・会議後に視界が0.0になる問題
・/sayコマンドがホストが霊界にいる場合生存者に見えない問題