### PR TITLE
ホストがキックされる問題・ゲーム設定が正しく反映されない問題の修正

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -95,7 +95,7 @@ public static class AntiBlackout
         foreach (var pc in Main.AllPlayerControls.Where(x => !x.Data.Disconnected))
         {
             if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId) continue;
-            if (pc.IsAlive() && pc.GetCustomRole().GetRoleInfo().IsDesyncImpostor) continue;
+            if (pc.IsAlive() && pc.GetCustomRole().GetRoleInfo()?.IsDesyncImpostor == true) continue;
             foreach (var dummy in list)
             {
                 dummy.RpcSetRoleDesync(RoleTypes.Impostor, pc.GetClientId());

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -222,8 +222,7 @@ static class ExtendedPlayerControl
         {
             Main.AllPlayerKillCooldown[player.PlayerId] *= 2;
         }
-        player.SyncSettings();
-        player.RpcProtectedMurderPlayer();
+        player.SyncSettings();        
         player.ResetKillCooldown();
     }
     public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null)

--- a/Modules/GameOptionsSender/NormalGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/NormalGameOptionsSender.cs
@@ -48,6 +48,11 @@ namespace TownOfHostY.Modules
         private LogicOptions _logicOptions;
 
         public override IGameOptions BuildGameOptions()
-            => BasedGameOptions;
+        {
+            var opt = BasedGameOptions;
+            if (opt != null && Main.RealOptionsData != null)
+                Main.RealOptionsData.Restore(opt);
+            return opt;
+        }
     }
 }

--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -85,8 +85,7 @@ namespace TownOfHostY.Modules
 
             var opt = BasedGameOptions;
             AURoleOptions.SetOpt(opt);
-            var state = PlayerState.GetByPlayerId(player.PlayerId);
-            Logger.Info($"[VisionDebug] {player?.Data?.PlayerName}: IsBlackOut={state.IsBlackOut}, DefaultCrewVision={Main.DefaultCrewmateVision}, RestoreCrewVision={opt.GetFloat(FloatOptionNames.CrewLightMod)}", "BuildGameOptions");
+            var state = PlayerState.GetByPlayerId(player.PlayerId);            
             if (state.IsBlackOut)
             {
                 opt.SetFloat(FloatOptionNames.CrewLightMod, 0f);
@@ -138,7 +137,7 @@ namespace TownOfHostY.Modules
 
             if (Main.AllPlayerSpeed.TryGetValue(player.PlayerId, out var speed))
             {
-                AURoleOptions.PlayerSpeedMod = Mathf.Clamp(speed, Main.MinSpeed, 10f);
+                AURoleOptions.PlayerSpeedMod = Mathf.Clamp(speed, Main.MinSpeed, 3f);
             }
 
             state.taskState.hasTasks = Utils.HasTasks(player.Data, false);

--- a/Modules/MeetingVoteManager.cs
+++ b/Modules/MeetingVoteManager.cs
@@ -135,6 +135,7 @@ public class MeetingVoteManager
                 logger.Warn($"{Utils.GetPlayerById(voteArea.TargetPlayerId).GetNameWithRole()} の投票データがありません");
                 continue;
             }
+            if (voteData.VotedFor == NoVote) continue;
             for (var i = 0; i < voteData.NumVotes; i++)
             {
                 states.Add(new()
@@ -147,20 +148,21 @@ public class MeetingVoteManager
 
         if (exiled != null) AntiBlackout.ExiledPlayerId = exiled.PlayerId;
         Logger.Info($"ExiledPlayerIdSet exiled: {exiled?.name}", "AntiBlackout");
-        if (AntiBlackout.OverrideExiledPlayer)
+        if (!AntiBlackout.OverrideExiledPlayer)
         {
-          
-            AntiBlackout.SetIsDead();
-            meetingHud.RpcVotingComplete(states.ToArray(), null, true);
-            ExileControllerWrapUpPatch.AntiBlackout_LastExiled = exiled;
-        }
-        else
-        {
-            // OverrideしないケースはアニメーションのLateTaskで SetIsDead
             _ = new LateTask(() =>
             {
                 AntiBlackout.SetIsDead();
             }, 4f, "LateAntiBlackoutSetIsDead");
+        }
+        if (AntiBlackout.OverrideExiledPlayer)
+        {
+            ExileControllerWrapUpPatch.AntiBlackout_LastExiled = exiled;
+            AntiBlackout.SetIsDead();
+            meetingHud.RpcVotingComplete(states.ToArray(), null, true);
+        }
+        else
+        {
             meetingHud.RpcVotingComplete(states.ToArray(), exiled, result.IsTie);
         }
         if (exiled != null)
@@ -202,6 +204,10 @@ public class MeetingVoteManager
             {
                 continue;
             }
+            var voter = Utils.GetPlayerById(vote.Voter);
+            if (voter == null) continue;
+            if (PlayerState.GetByPlayerId(vote.Voter).IsDead) continue;
+
             votes[vote.VotedFor] += vote.NumVotes;
         }
 

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -1086,8 +1086,8 @@ public static class Options
                 doOverride.ReplacementDictionary = replacementDic;
             }
 
-            assignCommonTasks = StringOptionItem.Create(idStart++, "assignCommonTasks", new string[] { "ColoredOff", "ColoredOn" }, 0, tab, false).SetParent(doOverride)
-                .SetValueFormat(OptionFormat.None);
+            assignCommonTasks = IntegerOptionItem.Create(idStart++, "assignCommonTasks", new(0, 99, 1), 0, tab, false).SetParent(doOverride)
+                .SetValueFormat(OptionFormat.Pieces);
             numLongTasks = IntegerOptionItem.Create(idStart++, "roleLongTasksNum", new(0, 99, 1), 3, tab, false).SetParent(doOverride)
                 .SetValueFormat(OptionFormat.Pieces);
             numShortTasks = IntegerOptionItem.Create(idStart++, "roleShortTasksNum", new(0, 99, 1), 3, tab, false).SetParent(doOverride)

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -67,6 +67,16 @@ namespace TownOfHostY
                     string name = subReader.ReadString();
                     if (subReader.BytesRemaining > 0 && subReader.ReadBoolean()) return false;
                     Logger.Info("名前変更:" + __instance.GetNameWithRole() + " => " + name, "SetName");
+                    if (name.Length > 350 && AmongUsClient.Instance.AmHost)
+                    {
+                        int chunkSize = 350;
+                        for (int i = 0; i < name.Length; i += chunkSize)
+                        {
+                            string chunk = name.Substring(i, Math.Min(chunkSize, name.Length - i));
+                            __instance.SetName(chunk);
+                        }
+                        return false;
+                    }
                     break;
                 case RpcCalls.SetRole: //SetNameRPC
                     var role = (RoleTypes)subReader.ReadUInt16();
@@ -150,10 +160,32 @@ namespace TownOfHostY
                     RPC.RpcVersionCheck();
                     break;
                 case CustomRPC.SyncCustomSettings:
-                    foreach (var co in OptionItem.AllOptions)
+                    int indexId = reader.ReadPackedInt32();
+                    int maxId = reader.ReadPackedInt32();
+                    for (var i = indexId; i < maxId; i++)
+                        OptionItem.AllOptions[i].SetValue(reader.ReadPackedInt32());
+
+                    // インポスター数が0に設定されていないかチェック
+                    if (AmongUsClient.Instance.AmHost)
                     {
-                        //すべてのカスタムオプションについてインデックス値で受信
-                        co.SetValue(reader.ReadPackedInt32());
+                        var options = GameOptionsManager.Instance.CurrentGameOptions;
+                        if (options != null)
+                        {
+                            int numImpostors = options.GetInt(Int32OptionNames.NumImpostors);
+                            if (numImpostors <= 0)
+                            {
+                                Logger.Warn("インポスター数が0に設定されているため、1に修正します。", "SyncCustomSettings");
+                                options.SetInt(Int32OptionNames.NumImpostors, 1);
+                            }
+
+                            // プレイヤー移動速度が3.0xを超えていないかチェック
+                            float playerSpeed = options.GetFloat(FloatOptionNames.PlayerSpeedMod);
+                            if (playerSpeed > 3.0f)
+                            {
+                                Logger.Warn($"プレイヤー移動速度が3.0xを超えているため、3.0に修正します。(元の値: {playerSpeed})", "SyncCustomSettings");
+                                options.SetFloat(FloatOptionNames.PlayerSpeedMod, 3.0f);
+                            }
+                        }
                     }
                     break;
                 case CustomRPC.SetDeathReason:
@@ -195,13 +227,26 @@ namespace TownOfHostY
         public static void SyncCustomSettingsRPC()
         {
             if (!AmongUsClient.Instance.AmHost) return;
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncCustomSettings, Hazel.SendOption.Reliable, -1);
+
+            int count = 0;
+            MessageWriter writer = null;
+
             foreach (var co in OptionItem.AllOptions)
             {
-                //すべてのカスタムオプションについてインデックス値で送信
+                if (count == 0 || count % 500 == 0)
+                {
+                    if (writer != null) AmongUsClient.Instance.FinishRpcImmediately(writer);
+                    writer = AmongUsClient.Instance.StartRpcImmediately(
+                        PlayerControl.LocalPlayer.NetId,
+                        (byte)CustomRPC.SyncCustomSettings,
+                        Hazel.SendOption.Reliable, -1);
+                    writer.WritePacked(count);
+                    writer.WritePacked(Math.Min(OptionItem.AllOptions.Count, count + 500));
+                }
                 writer.WritePacked(co.GetValue());
+                count++;
             }
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            if (writer != null) AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
         public static void PlaySoundRPC(byte PlayerID, Sounds sound)
         {

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -993,16 +993,98 @@ public static class Utils
         if (!AmongUsClient.Instance.AmHost) return;
         if (title == "") title = "<color=#aaaaff>" + GetString("DefaultSystemMessageTitle") + "</color>";
         else title = title.Color(Color.white);
-        Logger.Info($"[MessagesToSend.Add] sendTo: {sendTo}", "SendMessage");
-        string fullText = $"{title}\n<align={"left"}><size=90%>{text}</size></align>";
-        Main.MessagesToSend.Add(($"<align={"left"}>{fullText}</align>", sendTo, "", true));
+
+
+        string fullText = $"{title}\n{text}";
+
+        if (fullText.Length <= 320 && (fullText.Split("\n")?.Count() ?? 0) <= 13)
+        {           
+            Main.MessagesToSend.Add((fullText, sendTo, "", true));
+            return;
+        }
+
+        var lines = text.Split("\n").ToList();
+        var chunk = new List<string>();
+
+        for (int i = 0; i < lines.Count; i++)
+        {
+            chunk.Add(lines[i]);
+
+            string chunkText = $"{title}\n{string.Join("\n", chunk)}";
+            bool willExceed = chunkText.Length > 320 || chunk.Count >= 13;
+
+            if (willExceed)
+            {               
+                Main.MessagesToSend.Add(($"{title}\n{string.Join("\n", chunk.Take(chunk.Count - 1))}", sendTo, "", true));
+                chunk.Clear();
+                chunk.Add(lines[i]);
+            }
+        }
+
+        if (chunk.Count > 0)
+        {            
+            Main.MessagesToSend.Add(($"{title}\n{string.Join("\n", chunk)}", sendTo, "", true));
+        }
     }
     public static void SendMessageCustom(string text, byte sendTo = byte.MaxValue)
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-        Logger.Info($"[MessagesToSend.Add] sendTo: {sendTo}", "SendMessageCustom");
-        Main.MessagesToSend.Add(($"<align={"left"}><size=90%>{text}</size></align>", sendTo, "", true));
+        const int MaxLength = 320;
+        const int MaxLines = 13;
+
+        string formattedText = $"<align=left><size=90%>{text}</size></align>";
+
+        if (formattedText.Length <= MaxLength &&
+            (formattedText.Split("\n")?.Count() ?? 0) <= MaxLines)
+        {            
+            Main.MessagesToSend.Add((formattedText, sendTo, "", true));
+            return;
+        }
+
+        var lines = text.Split("\n").ToList();
+        var chunk = new List<string>();
+
+        for (int i = 0; i < lines.Count; i++)
+        {
+            chunk.Add(lines[i]);
+
+            string chunkRaw = string.Join("\n", chunk);
+            string chunkFormatted = $"<align=left><size=90%>{chunkRaw}</size></align>";
+
+            bool willExceed =
+                chunkFormatted.Length > MaxLength ||
+                chunk.Count > MaxLines;
+
+            if (willExceed)
+            {
+                string sendRaw = string.Join("\n", chunk.Take(chunk.Count - 1));
+                string sendFormatted = $"<align=left><size=90%>{sendRaw}</size></align>";
+
+                if (!string.IsNullOrWhiteSpace(sendRaw))
+                {
+                    Logger.Info($"[MessagesToSend.Add] sendTo: {sendTo}", "SendMessageCustom");
+
+                    Main.MessagesToSend.Add((sendFormatted, sendTo, "", true));
+                }
+
+                chunk.Clear();
+                chunk.Add(lines[i]);
+            }
+        }
+
+        if (chunk.Count > 0)
+        {
+            string sendRaw = string.Join("\n", chunk);
+            string sendFormatted = $"<align=left><size=90%>{sendRaw}</size></align>";
+
+            if (!string.IsNullOrWhiteSpace(sendRaw))
+            {
+                Logger.Info($"[MessagesToSend.Add] sendTo: {sendTo}", "SendMessageCustom");
+
+                Main.MessagesToSend.Add((sendFormatted, sendTo, "", true));
+            }
+        }
     }
     public static void ApplySuffix()
     {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -334,22 +334,78 @@ namespace TownOfHostY
         public static void SendCustomChat(string SendName, string command, string name, PlayerControl sender = null)
         {
             Logger.Info($"SendCustomChat SendName: {SendName}, command: {command}, name: {name} sender: {sender?.name}", "SendCustomChat");
-            if (sender == null) sender = PlayerControl.LocalPlayer;
+
+            if (sender == null)
+                sender = PlayerControl.LocalPlayer;
+
+            const int MaxLength = 320;
+            const int MaxLines = 13;
+
+           
+            if (command.Length <= MaxLength &&
+                (command.Split("\n")?.Count() ?? 0) <= MaxLines)
+            {
+                SendChunk(SendName, command, name, sender);
+                return;
+            }
+           
+            var lines = command.Split("\n").ToList();
+            var chunk = new List<string>();
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                chunk.Add(lines[i]);
+
+                string chunkText = string.Join("\n", chunk);
+
+                bool willExceed =
+                    chunkText.Length > MaxLength ||
+                    chunk.Count > MaxLines;
+
+                if (willExceed)
+                {                    
+                    string sendText = string.Join("\n", chunk.Take(chunk.Count - 1));
+
+                    if (!string.IsNullOrWhiteSpace(sendText))
+                    {
+                        SendChunk(SendName, sendText, name, sender);
+                    }
+                    
+                    chunk.Clear();
+                    chunk.Add(lines[i]);
+                }
+            }
+            
+            if (chunk.Count > 0)
+            {
+                string sendText = string.Join("\n", chunk);
+
+                if (!string.IsNullOrWhiteSpace(sendText))
+                {
+                    SendChunk(SendName, sendText, name, sender);
+                }
+            }
+        }
+
+        private static void SendChunk(string SendName, string text, string name, PlayerControl sender)
+        {
             var crs = CustomRpcSender.Create("AllSend");
+
             crs.AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
                 .Write(sender.Data.NetId)
                 .Write(SendName)
                 .EndRpc()
                 .AutoStartRpc(sender.NetId, (byte)RpcCalls.SendChat)
-                .Write(command)
+                .Write(text)
                 .EndRpc()
                 .AutoStartRpc(sender.NetId, (byte)RpcCalls.SetName)
                 .Write(sender.Data.NetId)
                 .Write(name)
                 .EndRpc()
                 .SendMessage();
+
             sender.SetName(SendName);
-            DestroyableSingleton<HudManager>.Instance.Chat.AddChat(sender, command);
+            DestroyableSingleton<HudManager>.Instance.Chat.AddChat(sender, text);
             sender.SetName(name);
         }
 
@@ -596,21 +652,29 @@ namespace TownOfHostY
                 DestroyableSingleton<HudManager>.Instance.Chat.AddChat(player, msg);
                 player.SetName(name);
             }
-            var writer = CustomRpcSender.Create("MessagesToSend", SendOption.None);
-            writer.StartMessage(clientId);
-            writer.StartRpc(player.NetId, (byte)RpcCalls.SetName)
-                .Write(player.Data.NetId)
-                .Write(title)
-                .EndRpc();
-            writer.StartRpc(player.NetId, (byte)RpcCalls.SendChat)
-                .Write(msg)
-                .EndRpc();
-            writer.StartRpc(player.NetId, (byte)RpcCalls.SetName)
-                .Write(player.Data.NetId)
-                .Write(player.Data.PlayerName)
-                .EndRpc();
-            writer.EndMessage();
-            writer.SendMessage();
+
+            if (player.Data.IsDead && GameStates.IsInGame)
+            {
+                SendMessageAsDeadHost(player, msg, title, sendTo);
+            }
+            else
+            {
+                var writer = CustomRpcSender.Create("MessagesToSend", SendOption.None);
+                writer.StartMessage(clientId);
+                writer.StartRpc(player.NetId, (byte)RpcCalls.SetName)
+                    .Write(player.Data.NetId)
+                    .Write(title)
+                    .EndRpc();
+                writer.StartRpc(player.NetId, (byte)RpcCalls.SendChat)
+                    .Write(msg)
+                    .EndRpc();
+                writer.StartRpc(player.NetId, (byte)RpcCalls.SetName)
+                    .Write(player.Data.NetId)
+                    .Write(player.Data.PlayerName)
+                    .EndRpc();
+                writer.EndMessage();
+                writer.SendMessage();
+            }
             __instance.timeSinceLastMessage = 0f;
         }
         public static void SendCustomChat(string SendName, PlayerControl sender = null, byte sendTo = byte.MaxValue)
@@ -618,12 +682,6 @@ namespace TownOfHostY
             Logger.Info($"sender: {sender?.name}, sendTo: {sendTo}", "SendCustomChat");
             string command = "\n\n";
             sender = PlayerControl.LocalPlayer;
-            // ホストが死亡している場合は生存しているプレイヤーに送らせる
-            if (sender.Data.IsDead && GameStates.IsInGame)
-            {
-                var aliveSender = Main.AllAlivePlayerControls.FirstOrDefault();
-                if (aliveSender != null) sender = aliveSender;
-            }
             string name = sender.Data?.PlayerName;
             int clientId = sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
             if (clientId == -1)
@@ -632,21 +690,78 @@ namespace TownOfHostY
                 DestroyableSingleton<HudManager>.Instance.Chat.AddChat(sender, command);
                 sender.SetName(name);
             }
-            var writer = CustomRpcSender.Create("CustomSend");
-            writer.StartMessage(clientId);
-            writer.StartRpc(sender.NetId, (byte)RpcCalls.SetName)
-                .Write(sender.Data.NetId)
-                .Write(SendName)
-                .EndRpc()
-                .StartRpc(sender.NetId, (byte)RpcCalls.SendChat)
-                .Write(command)
-                .EndRpc()
-                .StartRpc(sender.NetId, (byte)RpcCalls.SetName)
-                .Write(sender.Data.NetId)
-                .Write(name)
-                .EndRpc()
-                .EndMessage()
-                .SendMessage();
+
+            if (sender.Data.IsDead && GameStates.IsInGame)
+            {
+                SendMessageAsDeadHost(sender, command, SendName, sendTo);
+            }
+            else
+            {
+                var writer = CustomRpcSender.Create("CustomSend");
+                writer.StartMessage(clientId);
+                writer.StartRpc(sender.NetId, (byte)RpcCalls.SetName)
+                    .Write(sender.Data.NetId)
+                    .Write(SendName)
+                    .EndRpc()
+                    .StartRpc(sender.NetId, (byte)RpcCalls.SendChat)
+                    .Write(command)
+                    .EndRpc()
+                    .StartRpc(sender.NetId, (byte)RpcCalls.SetName)
+                    .Write(sender.Data.NetId)
+                    .Write(name)
+                    .EndRpc()
+                    .EndMessage()
+                    .SendMessage();
+            }
+        }
+        private static void SendMessageAsDeadHost(PlayerControl host, string msg, string title, byte sendTo)
+        {
+            var targets = sendTo == byte.MaxValue
+                ? Main.AllPlayerControls.Where(pc => pc.PlayerId != host.PlayerId)
+                : new[] { Utils.GetPlayerById(sendTo) };
+
+            foreach (var target in targets)
+            {
+                if (target == null) continue;
+                int targetClientId = target.GetClientId();
+                if (targetClientId == -1) continue;
+
+                var writer = CustomRpcSender.Create("DeadHostChat", SendOption.None);
+                writer.StartMessage(targetClientId);
+
+                if (target.IsAlive())
+                {
+                    host.Data.IsDead = false;
+                    writer.stream.StartMessage(1);
+                    writer.stream.WritePacked(host.Data.NetId);
+                    host.Data.Serialize(writer.stream, false);
+                    writer.stream.EndMessage();
+                }
+
+                writer.StartRpc(host.NetId, (byte)RpcCalls.SetName)
+                    .Write(host.Data.NetId)
+                    .Write(title)
+                    .EndRpc();
+                writer.StartRpc(host.NetId, (byte)RpcCalls.SendChat)
+                    .Write(msg)
+                    .EndRpc();
+                writer.StartRpc(host.NetId, (byte)RpcCalls.SetName)
+                    .Write(host.Data.NetId)
+                    .Write(host.Data.PlayerName)
+                    .EndRpc();
+
+                if (target.IsAlive())
+                {
+                    host.Data.IsDead = true;
+                    writer.stream.StartMessage(1);
+                    writer.stream.WritePacked(host.Data.NetId);
+                    host.Data.Serialize(writer.stream, false);
+                    writer.stream.EndMessage();
+                }
+
+                writer.EndMessage();
+                writer.SendMessage();
+            }
         }
     }
 

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -40,17 +40,17 @@ namespace TownOfHostY
                 Logger.Info($"GameEnd winner: {CustomWinnerHolder.WinnerTeam}, reason: {reason}", "GameEndChecker");
                 //カモフラージュ強制解除
                 Main.AllPlayerControls.Do(pc =>
-                    {
-                        Camouflage.RpcSetSkin(false, pc, ForceRevert: true, RevertToDefault: true);
-                        SkinChangeMode.RpcSetSkin(pc, pc);
-                    });
+                {
+                    Camouflage.RpcSetSkin(false, pc, ForceRevert: true, RevertToDefault: true);
+                    SkinChangeMode.RpcSetSkin(pc, pc);
+                });
 
                 switch (CustomWinnerHolder.WinnerTeam)
                 {
                     case CustomWinner.Crewmate:
                         foreach (var pc in PlayerControl.AllPlayerControls)
                         {
-                            if(pc.Is(CustomRoleTypes.Crewmate) && !pc.Is(CustomRoles.Lovers)
+                            if (pc.Is(CustomRoleTypes.Crewmate) && !pc.Is(CustomRoles.Lovers)
                                 && !(pc.Is(CustomRoles.Bakery) && Bakery.IsNeutral(pc)) && !pc.Is(CustomRoles.Archenemy))
                             {
                                 CustomWinnerHolder.WinnerIds.Add(pc.PlayerId);
@@ -61,7 +61,7 @@ namespace TownOfHostY
                         if (Egoist.CheckWin()) break;
 
                         Main.AllPlayerControls
-                            .Where(pc => (pc.Is(CustomRoleTypes.Impostor) || pc.Is(CustomRoleTypes.Madmate)) && !pc.Is(CustomRoles.Lovers) && !pc.Is(CustomRoles.Archenemy))
+                            .Where(pc => (pc.Is(CustomRoleTypes.Impostor) || pc.Is(CustomRoleTypes.Madmate)) && !pc.Is(CustomRoles.Lovers) && !pc.Is(CustomRoles.Archenemy) && !pc.Is(CustomRoles.MadJester))
                             .Do(pc => CustomWinnerHolder.WinnerIds.Add(pc.PlayerId));
                         break;
                 }
@@ -129,7 +129,7 @@ namespace TownOfHostY
                         }
                         if (Duelist.ArchenemyCheckWin(pc))
                         {
-                            if(!CustomWinnerHolder.WinnerIds.Contains(pc.PlayerId))
+                            if (!CustomWinnerHolder.WinnerIds.Contains(pc.PlayerId))
                                 CustomWinnerHolder.WinnerIds.Add(pc.PlayerId);
                             CustomWinnerHolder.AdditionalWinnerRoles.Add(CustomRoles.Archenemy);
                         }

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -1,5 +1,7 @@
 using AmongUs.Data;
+using BepInEx.Unity.IL2CPP.Utils.Collections;
 using HarmonyLib;
+using System.Collections;
 using TownOfHostY.Roles.AddOns.Common;
 using TownOfHostY.Roles.Core;
 using TownOfHostY.Roles.Crewmate;
@@ -26,18 +28,26 @@ namespace TownOfHostY
             }
         }
 
-        [HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.WrapUpAndSpawn))]
+        [HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.Animate))]
         class AirshipExileControllerPatch
         {
-            public static void Postfix(AirshipExileController __instance)
+            public static void Postfix(AirshipExileController __instance, ref Il2CppSystem.Collections.IEnumerator __result)
             {
+                __result = WrapAnimateCoroutine(__instance, __result).WrapToIl2Cpp();
+            }
+            static System.Collections.IEnumerator WrapAnimateCoroutine(AirshipExileController instance, Il2CppSystem.Collections.IEnumerator original)
+            {
+                while (original.MoveNext())
+                {
+                    yield return original.Current;
+                }
                 try
                 {
-                    WrapUpPostfix(__instance.initData.networkedPlayer);
+                    WrapUpPostfix(instance.initData.networkedPlayer);
                 }
                 finally
                 {
-                    WrapUpFinalizer(__instance.initData.networkedPlayer);
+                    WrapUpFinalizer(instance.initData.networkedPlayer);
                 }
             }
         }
@@ -49,55 +59,65 @@ namespace TownOfHostY
             }
 
             bool DecidedWinner = false;
-            if (!AmongUsClient.Instance.AmHost) return;
-            AntiBlackout.RestoreIsDead(doSend: false);
-            if (exiled != null)
+            if (AmongUsClient.Instance.AmHost)
             {
-                var role = exiled.GetCustomRole();
-                var info = role.GetRoleInfo();
-                //霊界用暗転バグ対処
-                if (!AntiBlackout.OverrideExiledPlayer && info?.IsDesyncImpostor == true)
-                    exiled.Object?.ResetPlayerCam(1f);
-
-                exiled.IsDead = true;
-                if (role != CustomRoles.AntiComplete || PlayerState.GetByPlayerId(exiled.PlayerId).DeathReason == CustomDeathReason.etc)
-                    PlayerState.GetByPlayerId(exiled.PlayerId).DeathReason = CustomDeathReason.Vote;
-
-                foreach (var roleClass in CustomRoleManager.AllActiveRoles.Values)
+                AntiBlackout.RestoreIsDead(doSend: false);
+                if (exiled != null)
                 {
-                    roleClass.OnExileWrapUp(exiled, ref DecidedWinner);
-                }
-                Sending.OnExileWrapUp(exiled.Object);
+                    var role = exiled.GetCustomRole();
+                    var info = role.GetRoleInfo();
+                    //霊界用暗転バグ対処
+                    if (!AntiBlackout.OverrideExiledPlayer && info?.IsDesyncImpostor == true)
+                        exiled.Object?.ResetPlayerCam(1f);
 
-                if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) PlayerState.GetByPlayerId(exiled.PlayerId).SetDead();
+                    exiled.IsDead = true;
+                    if (role != CustomRoles.AntiComplete || PlayerState.GetByPlayerId(exiled.PlayerId).DeathReason == CustomDeathReason.etc)
+                        PlayerState.GetByPlayerId(exiled.PlayerId).DeathReason = CustomDeathReason.Vote;
+
+                    foreach (var roleClass in CustomRoleManager.AllActiveRoles.Values)
+                    {
+                        roleClass.OnExileWrapUp(exiled, ref DecidedWinner);
+                    }
+                    Sending.OnExileWrapUp(exiled.Object);
+
+                    if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) PlayerState.GetByPlayerId(exiled.PlayerId).SetDead();
+                }
             }
-            // ランダムスポーン
-            switch ((MapNames)Main.NormalOptions.MapId)
+            AfterMeetingTasks();
+        }
+        static void AfterMeetingTasks()
+        {
+            if (AmongUsClient.Instance.AmHost)
             {
-                case MapNames.Skeld:
-                    if (Options.RandomSpawn_Skeld.GetBool())
-                    {
-                        Main.AllPlayerControls.Do(new RandomSpawn.SkeldSpawnMap().RandomTeleport);
-                    }
-                    break;
-                case MapNames.MiraHQ:
-                    if (Options.RandomSpawn_MiraHQ.GetBool())
-                    {
-                        Main.AllPlayerControls.Do(new RandomSpawn.MiraHQSpawnMap().RandomTeleport);
-                    }
-                    break;
-                case MapNames.Polus:
-                    if (Options.RandomSpawn_Polus.GetBool())
-                    {
-                        Main.AllPlayerControls.Do(new RandomSpawn.PolusSpawnMap().RandomTeleport);
-                    }
-                    break;
-                case MapNames.Fungle:
-                    if (Options.RandomSpawn_Fungle.GetBool())
-                    {
-                        Main.AllPlayerControls.Do(new RandomSpawn.FungleSpawnMap().RandomTeleport);
-                    }
-                    break;
+                if (CustomWinnerHolder.WinnerTeam is not CustomWinner.Default) return;
+                // ランダムスポーン
+                switch ((MapNames)Main.NormalOptions.MapId)
+                {
+                    case MapNames.Skeld:
+                        if (Options.RandomSpawn_Skeld.GetBool())
+                        {
+                            Main.AllPlayerControls.Do(new RandomSpawn.SkeldSpawnMap().RandomTeleport);
+                        }
+                        break;
+                    case MapNames.MiraHQ:
+                        if (Options.RandomSpawn_MiraHQ.GetBool())
+                        {
+                            Main.AllPlayerControls.Do(new RandomSpawn.MiraHQSpawnMap().RandomTeleport);
+                        }
+                        break;
+                    case MapNames.Polus:
+                        if (Options.RandomSpawn_Polus.GetBool())
+                        {
+                            Main.AllPlayerControls.Do(new RandomSpawn.PolusSpawnMap().RandomTeleport);
+                        }
+                        break;
+                    case MapNames.Fungle:
+                        if (Options.RandomSpawn_Fungle.GetBool())
+                        {
+                            Main.AllPlayerControls.Do(new RandomSpawn.FungleSpawnMap().RandomTeleport);
+                        }
+                        break;
+                }
             }
             FallFromLadder.Reset();
             Utils.CountAlivePlayers(true);
@@ -113,7 +133,6 @@ namespace TownOfHostY
                 _ = new LateTask(() =>
                 {
                     exiled = AntiBlackout_LastExiled;
-                    AntiBlackout.SendGameData();
                     if (AntiBlackout.OverrideExiledPlayer &&
                         exiled != null &&
                         exiled.Object != null)
@@ -134,8 +153,8 @@ namespace TownOfHostY
                         var state = PlayerState.GetByPlayerId(playerId);
                         Logger.Info($"{player.GetNameWithRole()}を{reason}で死亡させました", "AfterMeetingDeath");
                         state.DeathReason = reason;
-                        state.SetDead();
                         player?.RpcExileV3();
+                        state.SetDead();
                         if (reason == CustomDeathReason.Suicide)
                             player?.SetRealKiller(player, true);
                         if (requireResetCam)
@@ -147,13 +166,13 @@ namespace TownOfHostY
                         Elder.DeadByRevenge(playerId);
                     });
                     Main.AfterMeetingDeathPlayers.Clear();
-                }, 0.5f, "AfterMeetingDeathPlayers Task");
+                }, 0.6f, "AfterMeetingDeathPlayers Task");
 
 
                 _ = new LateTask(() =>
                 {
                     Main.AllPlayerControls.Do(pc => AntiBlackout.ResetSetRole(pc));
-                }, 0.6f, "AfterMeeting_ResetSetRole");
+                }, 0.65f, "AfterMeeting_ResetSetRole");
 
                 _ = new LateTask(() =>
                 {

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -429,8 +429,10 @@ public static class GameOptionsMenuPatch
                     }
                 }
 
-                __instance.UpdateValue();
-                __instance.OnValueChanged?.Invoke(__instance);
+                // 初期化時はUIテキスト更新のみ。UpdateValue()を呼ぶとSetValue→SyncAllOptionsが
+                // 全オプション分連鎖してRPCが大量発生しhacking判定されるため直接表示を設定する
+                __instance.oldValue = __instance.Value;
+                __instance.ValueText.text = item.GetString();
                 return false;
             }
 

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -356,21 +356,19 @@ public static class GameOptionsMenuPatch
         }
         else if (item is StringOptionItem stringItem)
         {
-            baseGameSetting = new StringGameSetting
-            {
-                Type = OptionTypes.String,
-                Values = new StringNames[stringItem.Selections.Length],
-                Index = stringItem.GetInt(),
-            };
+            var stringSetting = ScriptableObject.CreateInstance<StringGameSetting>();
+            stringSetting.Type = OptionTypes.String;
+            stringSetting.Values = new StringNames[stringItem.Selections.Length];
+            stringSetting.Index = stringItem.GetInt();
+            baseGameSetting = stringSetting;
         }
         else if (item is PresetOptionItem presetItem)
         {
-            baseGameSetting = new StringGameSetting
-            {
-                Type = OptionTypes.String,
-                Values = new StringNames[OptionItem.NumPresets],
-                Index = presetItem.GetInt(),
-            };
+            var presetSetting = ScriptableObject.CreateInstance<StringGameSetting>();
+            presetSetting.Type = OptionTypes.String;
+            presetSetting.Values = new StringNames[OptionItem.NumPresets];
+            presetSetting.Index = presetItem.GetInt();
+            baseGameSetting = presetSetting;
 
         }
 

--- a/Patches/ISystemType/SwitchSystemPatch.cs
+++ b/Patches/ISystemType/SwitchSystemPatch.cs
@@ -11,8 +11,12 @@ namespace TownOfHostY.Patches.ISystemType;
 [HarmonyPatch(typeof(SwitchSystem), nameof(SwitchSystem.UpdateSystem))]
 public static class SwitchSystemUpdateSystemPatch
 {
+    private static bool wasActive;
+
     public static bool Prefix(SwitchSystem __instance, [HarmonyArgument(0)] PlayerControl player, [HarmonyArgument(1)] MessageReader msgReader)
     {
+        wasActive = __instance.IsActive;
+
         byte amount;
         {
             var newReader = MessageReader.Get(msgReader);
@@ -79,5 +83,14 @@ public static class SwitchSystemUpdateSystemPatch
             return false;
         }
         return true;
+    }
+
+    public static void Postfix(SwitchSystem __instance)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        if (wasActive != __instance.IsActive)
+        {
+            Utils.SyncAllSettings();
+        }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -322,7 +322,7 @@ public static class MeetingHudPatch
         public static void Postfix()
         {
             MeetingStates.FirstMeeting = false;
-            Logger.Info("------------会議終了------------", "Phase");            
+            Logger.Info("------------会議終了------------", "Phase");
             ChatUpdatePatch.DoBlockChat = false;
             if (AmongUsClient.Instance.AmHost)
             {
@@ -335,7 +335,7 @@ public static class MeetingHudPatch
                 {
                     if (!GameStates.IsInGame) return;
 
-                    
+
                     foreach (var pc in Main.AllPlayerControls)
                     {
                         if (pc.GetClientId() == -1) continue;
@@ -343,11 +343,14 @@ public static class MeetingHudPatch
                         var role = pc.GetCustomRole();
                         var roleInfo = role.GetRoleInfo();
 
-                        
+
                         if (pc.PlayerId == PlayerControl.LocalPlayer.PlayerId
                             && Options.EnableGM.GetBool()) continue;
 
-                        
+
+                        // 霊界（死亡済み）プレイヤーにはSetRoleしない
+                        if (PlayerState.GetByPlayerId(pc.PlayerId).IsDead) continue;
+
                         if (roleInfo?.IsDesyncImpostor == true) continue;
 
                         var baseRole = roleInfo?.BaseRoleType?.Invoke() ?? RoleTypes.Crewmate;

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -192,7 +192,6 @@ namespace TownOfHostY
             {
                 if (!AmongUsClient.Instance.AmHost) return;
                 if (client == null) return;
-
                 OptionItem.SyncAllOptions();
                 _ = new LateTask(() =>
                 {

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -30,10 +30,10 @@ namespace TownOfHostY
                     if (player.Is(CustomRoles.GM)) return; //GMは対象外に
                     if (FirstTP[player.PlayerId])
                     {
-                        FirstTP[player.PlayerId] = false;                                                
+                        FirstTP[player.PlayerId] = false;
                         var state = PlayerState.GetByPlayerId(player.PlayerId);
                         state.IsBlackOut = false;
-                        player.SyncSettings();
+                        Utils.SyncAllSettings();
 
                         if (Main.NormalOptions.MapId != 4) return; //マップがエアシップじゃなかったらreturn
                         player.RpcResetAbilityCooldown();

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -73,12 +73,14 @@ namespace TownOfHostY
 
             // デフォルトのタスク数
             bool hasCommonTasks = true;
+            int numCommonTasks = -1; 
             int NumLongTasks = Main.NormalOptions.NumLongTasks;
             int NumShortTasks = Main.NormalOptions.NumShortTasks;
 
             if (Options.OverrideTasksData.AllData.TryGetValue(role, out var data) && data.doOverride.GetBool())
             {
-                hasCommonTasks = data.assignCommonTasks.GetBool();
+                numCommonTasks = data.assignCommonTasks.GetInt();
+                hasCommonTasks = numCommonTasks > 0;
                 NumLongTasks = data.numLongTasks.GetInt();
                 NumShortTasks = data.numShortTasks.GetInt();
             }
@@ -96,7 +98,7 @@ namespace TownOfHostY
             if (!hasCommonTasks && NumLongTasks == 0 && NumShortTasks == 0) NumShortTasks = 1;
                        
             if (!pc.Is(CustomRoles.VentManager) && !pc.Is(CustomRoles.FoxSpirit)
-                && hasCommonTasks
+                && hasCommonTasks && numCommonTasks < 0
                 && NumLongTasks == Main.NormalOptions.NumLongTasks
                 && NumShortTasks == Main.NormalOptions.NumShortTasks)
             {
@@ -109,7 +111,10 @@ namespace TownOfHostY
                 TasksList.Add(num);
 
             int defaultCommonTasksNum = Main.RealOptionsData.GetInt(Int32OptionNames.NumCommonTasks);
-            if (hasCommonTasks) TasksList.RemoveRange(defaultCommonTasksNum, TasksList.Count - defaultCommonTasksNum);
+            int commonToKeep = numCommonTasks >= 0
+                ? (numCommonTasks < defaultCommonTasksNum ? numCommonTasks : defaultCommonTasksNum)
+                : defaultCommonTasksNum;
+            if (hasCommonTasks) TasksList.RemoveRange(commonToKeep, TasksList.Count - commonToKeep);
             else TasksList.Clear();
 
             Il2CppSystem.Collections.Generic.HashSet<TaskTypes> usedTaskTypes = new();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -435,7 +435,14 @@ class SelectRolesPatch
 
 
         RpcSetRoleReplacer.Release();
-        senders?.Do(kvp => kvp.Value.SendMessage());
+        senders?.Do(kvp =>
+        {
+            var s = kvp.Value;
+            if (s.CurrentState == CustomRpcSender.State.Ready)
+                s.SendMessage();
+            else
+                s.stream.Recycle();
+        });
 
         RpcSetRoleReplacer.senders = null;
         RpcSetRoleReplacer.OverriddenSenderList = null;
@@ -952,6 +959,7 @@ public static class StandardIntroHelper
                 sender.Write(AmongUsClient.Instance.GameId);
                 int idx = 0;
                 bool issend = false;
+                bool hasData = false;
                 foreach (var data in GameData.Instance.AllPlayers)
                 {
                     idx++;
@@ -964,6 +972,7 @@ public static class StandardIntroHelper
                             sender.Write(AmongUsClient.Instance.GameId);
                             issend = false;
                         }
+                        hasData = true;
                         data.Disconnected = false;
                         var pc2 = Utils.GetPlayerById(data.PlayerId);
                         var isDesync2 = pc2?.GetCustomRole().GetRoleInfo()?.IsDesyncImpostor == true;
@@ -985,10 +994,15 @@ public static class StandardIntroHelper
                         }
                     }
                 }
-                if (!issend)
+                // プレイヤー数が4以下の場合このバッチにデータがないため、空パケットを送らない
+                if (!issend && hasData)
                 {
                     sender.EndMessage();
                     AmongUsClient.Instance.SendOrDisconnect(sender);
+                    sender.Recycle();
+                }
+                else if (!issend)
+                {
                     sender.Recycle();
                 }
 

--- a/Roles/AddOns/Crewmate/CompreteCrew.cs
+++ b/Roles/AddOns/Crewmate/CompreteCrew.cs
@@ -33,6 +33,7 @@ namespace TownOfHostY.Roles.AddOns.Crewmate
 
         public static void OnCompleteTask(PlayerControl pc)
         {
+            if (!AmongUsClient.Instance.AmHost) return;
             if (!CustomRoles.CompleteCrew.IsEnable() || playerIdList.Count >= CustomRoles.CompleteCrew.GetCount()) return;
             if (!CanBeCompreteCrew(pc)) return;
 


### PR DESCRIPTION
ホストがHacking判定を受けることによりキックされる問題の修正
・RPCのパケット数の制限
・名前の文字数の制限
ホストのキック防止のためにシステムメッセージがかなり分割されて表示されるようになっています

コンプリートクルーに関する修正
追放処理が正しく行われない問題の修正
ゲーム設定画面での警告の修正
シェリフの視界が停電時に変わらない問題の修正
追加の通常タスクが正しく設定できない問題の修正
視界が正しくセットされない問題の修正